### PR TITLE
BACKLOG-21981: Expose shared functions in registry

### DIFF
--- a/src/javascript/CKEditor/registerConfig.js
+++ b/src/javascript/CKEditor/registerConfig.js
@@ -23,7 +23,7 @@ export function registerConfig() {
      */
     // expose (some) shared functions through registry with registry.get('@jahia/ckeditor5', 'shared');
     registry.addOrReplace(MODULE_KEY, 'shared', {
-        defineConfig, 
+        defineConfig,
         getDefaultConfig
     });
 }
@@ -47,7 +47,7 @@ export function defineConfig(key, config) {
 }
 
 export function getDefaultConfig() {
-    return registry.get('ckeditor5-config','default');
+    return registry.get('ckeditor5-config', 'default');
 }
 
 function initConfig() {

--- a/src/javascript/CKEditor/registerConfig.js
+++ b/src/javascript/CKEditor/registerConfig.js
@@ -16,13 +16,16 @@ export function registerConfig() {
 
     /**
      * Make config override function available through registry (to be tested) e.g.
-     *
      * ```
-     * const defineConfig = window.jahia.uiExtender.registry.get('richtext-ckeditor5', 'init');
+     * const {defineConfig} = window.jahia.uiExtender.registry.get('@jahia/ckeditor5', 'shared');
      * defineConfig('my-override', {...[config override]})
      * ```
      */
-    registry.addOrReplace(MODULE_KEY, 'init', defineConfig);
+    // expose (some) shared functions through registry with registry.get('@jahia/ckeditor5', 'shared');
+    registry.addOrReplace(MODULE_KEY, 'shared', {
+        defineConfig, 
+        getDefaultConfig
+    });
 }
 
 export function defineConfig(key, config) {
@@ -41,6 +44,10 @@ export function defineConfig(key, config) {
     registry.addOrReplace(BALLOON_PLUGINS_KEY, key, {targets: ['balloon'], plugins: plugins?.balloon || []});
 
     initConfig();
+}
+
+export function getDefaultConfig() {
+    return registry.get('ckeditor5-config','default');
 }
 
 function initConfig() {

--- a/src/javascript/RichTextCKEditor5.constants.js
+++ b/src/javascript/RichTextCKEditor5.constants.js
@@ -1,6 +1,6 @@
 const Constants = {
     registry: {
-        MODULE_KEY: 'richtext-ckeditor5',
+        MODULE_KEY: '@jahia/ckeditor5',
         CONFIG_KEY: 'ckeditor5-config',
         PLUGINS_KEY: 'ckeditor5-plugins',
         BALLOON_PLUGINS_KEY: 'ckeditor5-balloon-plugins'

--- a/src/javascript/shared/index.js
+++ b/src/javascript/shared/index.js
@@ -1,1 +1,1 @@
-export {defineConfig} from '../CKEditor/registerConfig';
+export * from '../CKEditor/registerConfig';


### PR DESCRIPTION
<!--
When lists are present, the item can be:
 - Deleted: The item is not applicable to the PR
 - Unchecked: The item is not done yet, but should be done as part of the PR
 - Checked: The item has been done
-->

## JIRA

<!-- 
Please link the JIRA issue related to this PR.
You can replace "PROJECT" by your project name in this template, so only the issue number needs to be replaced by the PR author.
-->

https://jira.jahia.org/browse/BACKLOG-21981

## Description

<!-- 
Please describe what your change is about. 
If you made specific implementation choices worth an explanation, those can be detailed in this section 
-->

- Refactor how we expose util functions in registry into a single entry: `registry.get('@jahia/ckeditor5', 'shared')`