### PR TITLE
feat: Add 'open in new tab' toggle in link properties

### DIFF
--- a/src/javascript/CKEditor/configurations/config-default.js
+++ b/src/javascript/CKEditor/configurations/config-default.js
@@ -115,5 +115,18 @@ export const config = {
             startIndex: true,
             reversed: false
         }
+    },
+    link: {
+        decorators: {
+            openInNewTab: {
+                mode: 'manual',
+                label: 'Open in a new tab',
+                defaultValue: false,
+                attributes: {
+                    target: '_blank',
+                    rel: 'noopener noreferrer'
+                }
+            }
+        }
     }
 };

--- a/tests/cypress/e2e/language.cy.ts
+++ b/tests/cypress/e2e/language.cy.ts
@@ -25,7 +25,7 @@ describe('Language tests', () => {
 
     it('should have labels in English', () => {
         jcontent = JContent.visit(siteKeyEn, 'en', 'content-folders/contents');
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.getToolbarButton('Bold').should('exist');
@@ -38,7 +38,7 @@ describe('Language tests', () => {
             variables: {lang: 'fr'}
         });
         jcontent = JContent.visit(siteKeyEn, 'en', 'content-folders/contents');
-        let contentEditor = jcontent.createContent('Texte riche');
+        let contentEditor = jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.type('Texte riche');

--- a/tests/cypress/e2e/link.cy.ts
+++ b/tests/cypress/e2e/link.cy.ts
@@ -1,0 +1,57 @@
+import {JContent} from '@jahia/jcontent-cypress/dist/page-object';
+import {addNode, createSite, deleteSite} from '@jahia/cypress';
+import {Ckeditor5, RichTextCKeditor5Field} from '../page-object/ckeditor5';
+
+describe('Link tests', () => {
+    const siteKey = 'linkCKEditor5Site';
+    const ckeditor5 = new Ckeditor5();
+    const textName = 'test-link2';
+
+    before(function () {
+        createSite(siteKey);
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/contents`,
+            name: textName,
+            primaryNodeType: 'jnt:bigText',
+            properties: [{name: 'text', language: 'en', value: '<p>this is <a href="https://google.com">my text</a> here</p>'}]
+        });
+    });
+
+    after(function () {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    it('should be able to toggle "Open in new tab" link property', () => {
+        JContent.visit(siteKey, 'en', `content-folders/contents/${textName}`).editContent();
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+        ck5field.getEditArea().contains('my text').click('center');
+
+        // Workaround to trigger the balloon toolbar for links
+        ck5field.getEditArea().type('{leftArrow}{leftArrow}{leftArrow}', {delay: 300});
+        ck5field.clickMenuItemByLabel('Insert');
+        ck5field.getMenuSubItemByLabel('Link').click();
+        ck5field.getBalloonToolbarButton('Back').click();
+
+        ck5field.getBalloonToolbarButton('Link properties').should('be.visible').click();
+
+        cy.log('Toggle open in new tab button');
+        const openNewTabToggle = ck5field.getBalloonToggleButton('Open in a new tab');
+        openNewTabToggle
+            .should('be.visible')
+            .and('have.class', 'ck-off')
+            .click();
+        openNewTabToggle.should('have.class', 'ck-on');
+
+        cy.log('Verify link contains target="_blank"');
+        ck5field.getToolbarButton('Source').click();
+        ck5field.getSourceEditingArea()
+            .should('be.visible')
+            .invoke('attr', 'data-value')
+            .should('contain', 'target="_blank"');
+    });
+});

--- a/tests/cypress/e2e/siteConfig.cy.ts
+++ b/tests/cypress/e2e/siteConfig.cy.ts
@@ -45,7 +45,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
 
     it('Can create content in content folders', function () {
         jcontent = visitContentFolders(siteKey, jcontent);
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text').type(newlyCreatedContentCKEditor5);
         ckeditor5.create();
@@ -59,7 +59,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
         });
 
         jcontent = visitContentFolders(siteKey, jcontent);
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor4 = new ContentEditor();
         ckeditor4.getRichTextField('jnt:bigText_text').type(newlyCreatedContentCKEditor4);
         ckeditor4.create();
@@ -110,7 +110,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
             variables: {siteKey: ''}
         });
 
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text').getToolbarButton('Insert image').click();
         cy.get('div[data-sel-role="picker-dialog"][data-sel-type="image"]').should('be.visible');
@@ -125,7 +125,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
             variables: {siteKey: ''}
         });
 
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text').getToolbarButton('Insert link').click();
         cy.get('div[data-sel-role="picker-dialog"][data-sel-type="editoriallink"]').should('be.visible');
@@ -140,7 +140,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
         });
 
         jcontent = visitContentFolders(siteKey, jcontent);
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor4 = new ContentEditor();
         ckeditor4.getRichTextField('jnt:bigText_text').type(newlyCreatedContentCKEditor4);
         ckeditor4.create();
@@ -159,7 +159,7 @@ describe('Rich Text CKeditor 5 - Site level configuration tests', () => {
         });
 
         jcontent = visitContentFolders(siteKey, jcontent);
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text').type(newlyCreatedContentCKEditor5);
         ckeditor5.create();

--- a/tests/cypress/e2e/toolbar.cy.ts
+++ b/tests/cypress/e2e/toolbar.cy.ts
@@ -22,7 +22,7 @@ describe('Toolbar tests', () => {
     });
 
     it('should have buttons visible and clickable', () => {
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.type('this is my text');
@@ -40,7 +40,7 @@ describe('Toolbar tests', () => {
     });
 
     it('should have full toolbar visible', () => {
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.type('this is my text');
@@ -106,7 +106,7 @@ describe('Toolbar tests', () => {
     });
 
     it('should have basic edit source working', () => {
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.type('this is my text');
@@ -119,7 +119,7 @@ describe('Toolbar tests', () => {
 
     // Enable when enhanced edit source is enabled in config
     it.skip('should have enhanced edit source working', () => {
-        jcontent.createContent('Rich text');
+        jcontent.createContent('jnt:bigText');
         const ckeditor5 = new Ckeditor5();
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.type('this is my text');

--- a/tests/cypress/page-object/ckeditor5.ts
+++ b/tests/cypress/page-object/ckeditor5.ts
@@ -7,15 +7,19 @@ export class Ckeditor5 extends ContentEditor {
 }
 
 export class RichTextCKeditor5Field extends Field {
+    getEditArea() {
+        return this.get().find('.ck-editor__editable');
+    }
+
     type(text: string) {
-        this.get().find('.ck-editor__editable').then($myElement => {
+        this.getEditArea().then($myElement => {
             const ckeditorInstance = $myElement.prop('ckeditorInstance');
             ckeditorInstance.setData(text);
         });
     }
 
     getData(): Cypress.Chainable<string> {
-        return this.get().find('.ck-editor__editable').then($myElement => {
+        return this.getEditArea().then($myElement => {
             const ckeditorInstance = $myElement.prop('ckeditorInstance');
             return ckeditorInstance.getData();
         });
@@ -31,6 +35,22 @@ export class RichTextCKeditor5Field extends Field {
 
     getToolbarButton(buttonName: string): Cypress.Chainable<JQuery<HTMLElement>> {
         return this.get().find('.ck-toolbar__items').find(`button[data-cke-tooltip-text^="${buttonName}"]`);
+    }
+
+    getBalloonToolbarButton(buttonName: string) {
+        return this.get().get('.ck-balloon-panel > .ck-balloon-rotator')
+            .should('be.visible')
+            .find(`button.ck-button[data-cke-tooltip-text="${buttonName}"]`);
+    }
+
+    getBalloonToggleButton(label: string) {
+        return this.get()
+            .get('.ck-balloon-panel > .ck-balloon-rotator')
+            .should('be.visible')
+            .find('button.ck-switchbutton')
+            .contains(label)
+            .should('be.visible')
+            .closest('button');
     }
 
     getMenuItemByLabel(label: string): Cypress.Chainable<JQuery<HTMLElement>> {

--- a/tests/package.json
+++ b/tests/package.json
@@ -24,7 +24,7 @@
     "@4tw/cypress-drag-drop": "^2.2.1",
     "@jahia/cypress": "^4.0.0",
     "@jahia/jahia-reporter": "^1.0.30",
-    "@jahia/jcontent-cypress": "^3.0.0-tests.8",
+    "@jahia/jcontent-cypress": "^3.2.0-tests.1",
     "@types/node": "^18.11.18",
     "@typescript-eslint/eslint-plugin": "^7.4.0",
     "@typescript-eslint/parser": "^7.4.0",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -168,10 +168,10 @@
     uuid "^8.3.1"
     xml-js "^1.6.11"
 
-"@jahia/jcontent-cypress@^3.0.0-tests.8":
-  version "3.0.0-tests.8"
-  resolved "https://registry.yarnpkg.com/@jahia/jcontent-cypress/-/jcontent-cypress-3.0.0-tests.8.tgz#c71139838f933ba0650d9356ba2c75e6ac7e9af6"
-  integrity sha512-yEs2NNMDKgxQ9bygPRw2a/T8dV1jGG3qnm5B/K2p/IplrpfIo7UzsHOR92TJ7fpBdMBWbf4lXxTWiAsZ1tjcxg==
+"@jahia/jcontent-cypress@^3.2.0-tests.1":
+  version "3.2.0-tests.1"
+  resolved "https://registry.yarnpkg.com/@jahia/jcontent-cypress/-/jcontent-cypress-3.2.0-tests.1.tgz#a4472d53291fff246388fa9dbedc5817a8ced32e"
+  integrity sha512-/69VlWGPZtqKb35djeZGfoCSjngdzBFAJZspowOjRvwq47a0iZmVmBhSoaFK4Ojoy6RL8WmTMYycKlkFySBIPA==
   dependencies:
     cypress-real-events "^1.7.6"
 


### PR DESCRIPTION
### Description

- Add link decorator to enable 'Open in new tab' toggle that adds `target="_blank" rel="noopener noreferrer"` to the link element (https://outreachmonks.com/rel-noopener-noreferrer/)
- Add cypress test; added helper methods for fetching balloon toolbar, toggle buttons
- Update @jahia/jcontent-cypress and tests for reuse existing functionalities

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
