### PR TITLE
fix: Fix licensing check and productivity plugin filer logic

### DIFF
--- a/src/javascript/CKEditor/JahiaClassicEditor.js
+++ b/src/javascript/CKEditor/JahiaClassicEditor.js
@@ -18,7 +18,7 @@ export class JahiaClassicEditor extends ClassicEditor {
         } else {
             config.licenseKey = 'GPL';
             JahiaClassicEditor.builtinPlugins = JahiaClassicEditor.builtinPlugins
-                .filter(p => Boolean(p.isPremiumPlugin));
+                .filter(p => !p.isPremiumPlugin);
         }
 
         if (!config.templates?.definitions) {

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -57,5 +57,7 @@ export const set = (target, path, value) => {
     }
 };
 
-// eslint-disable-next-line no-undef
-export const isProductivityMode = () => window?.contextJsParameters?.valid && Boolean(CKEDITOR_PRODUCTIVITY_LICENSE);
+export const isProductivityMode = () => {
+    // eslint-disable-next-line no-undef
+    return window?.contextJsParameters?.valid && (typeof CKEDITOR_PRODUCTIVITY_LICENSE !== 'undefined') && CKEDITOR_PRODUCTIVITY_LICENSE !== '';
+};


### PR DESCRIPTION
### Description

Fix incorrect filter logic for non-productivity license and remove Boolean wrapper that seems to be causing issues with webpack env insertion.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
