### PR TITLE
fix: Fix embedding of license in webpack

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -43,45 +43,53 @@ jobs:
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}
           nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-          module_id: richtext-ckeditor5
 
-  # integration-tests-standalone:
-  #   name: Integration Tests (Standalone)
-  #   needs: build
-  #   runs-on: self-hosted
-  #   timeout-minutes: 45
-  #   steps:
-  #     - uses: jahia/jahia-modules-action/helper@v2
-  #     - uses: KengoTODA/actions-setup-docker-compose@main
-  #       with:
-  #         version: '1.29.2'
-  #     - uses: actions/setup-node@v2
-  #       with:
-  #         node-version: 'lts/*'
-  #     - uses: actions/checkout@v4
-  #     - uses: jahia/jahia-modules-action/integration-tests@v2
-  #       with:
-  #         module_id: richtext-ckeditor5
-  #         testrail_project: Copy to all languages Module
-  #         tests_manifest: provisioning-manifest-build.yml
-  #         jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
-  #         github_artifact_name: richtext-ckeditor5-standalone-artifacts-${{ github.run_number }}
-  #         bastion_ssh_private_key: ${{ secrets.BASTION_SSH_PRIVATE_KEY_JAHIACI }}
-  #         jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
-  #         docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
-  #         docker_password: ${{ secrets.DOCKERHUB_PASSWORD }}
-  #         nexus_username: ${{ secrets.NEXUS_USERNAME }}
-  #         nexus_password: ${{ secrets.NEXUS_PASSWORD }}
-  #         tests_report_name: Test report (Standalone)
-  #         testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
-  #         testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
-  #         incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
-  #         incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
-  #         incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
-  #         incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
-  #         incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
-  #         incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
-  #         zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
+  integration-tests-standalone:
+    name: Integration Tests (Standalone)
+    needs: build
+    runs-on: self-hosted
+    timeout-minutes: 45
+    steps:
+      - uses: jahia/jahia-modules-action/helper@v2
+      - uses: KengoTODA/actions-setup-docker-compose@main
+        with:
+          version: '1.29.2'
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/*'
+      - uses: actions/checkout@v4
+      - uses: jahia/jahia-modules-action/integration-tests@v2
+        with:
+          module_id: richtext-ckeditor5
+          testrail_project: CKEditor 5 Module
+          tests_manifest: provisioning-manifest-build.yml
+          jahia_image: jahia/jahia-ee-dev:8-SNAPSHOT
+          should_skip_testrail: true
+          github_artifact_name: richtext-ckeditor5-standalone-artifacts-${{ github.run_number }}
+          jahia_license: ${{ secrets.JAHIA_LICENSE_8X_FULL }}
+          docker_username: ${{ secrets.DOCKERHUB_USERNAME }}
+          docker_password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          nexus_username: ${{ secrets.NEXUS_USERNAME }}
+          nexus_password: ${{ secrets.NEXUS_PASSWORD }}
+          tests_report_name: Test report (Standalone)
+          testrail_username: ${{ secrets.TESTRAIL_USERNAME }}
+          testrail_password: ${{ secrets.TESTRAIL_PASSWORD }}
+          incident_pagerduty_api_key: ${{ secrets.INCIDENT_PAGERDUTY_API_KEY }}
+          incident_pagerduty_reporter_email: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_EMAIL }}
+          incident_pagerduty_reporter_id: ${{ secrets.INCIDENT_PAGERDUTY_REPORTER_ID }}
+          incident_google_spreadsheet_id: ${{ secrets.INCIDENT_GOOGLE_SPREADSHEET_ID }}
+          incident_google_client_email: ${{ secrets.INCIDENT_GOOGLE_CLIENT_EMAIL }}
+          incident_google_api_key_base64: ${{ secrets.INCIDENT_GOOGLE_PRIVATE_KEY_BASE64 }}
+          zencrepes_secret: ${{ secrets.ZENCREPES_WEBHOOK_SECRET }}
+      - name: Test Report
+        uses: phoenix-actions/test-reporting@v12
+        if: success() || failure()
+        with:
+          name: Tests Report (Standalone)
+          path: tests/artifacts/results/xml_reports/**/*.xml
+          reporter: java-junit
+          fail-on-error: 'false'
+          output-to: 'checks'
 
   publish:
     name: Publish module

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -58,6 +58,11 @@ export const set = (target, path, value) => {
 };
 
 export const isProductivityMode = () => {
-    // eslint-disable-next-line no-undef
-    return window?.contextJsParameters?.valid && (typeof CKEDITOR_PRODUCTIVITY_LICENSE !== 'undefined') && CKEDITOR_PRODUCTIVITY_LICENSE !== '';
+    /**
+     * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
+     * We cannot use it directly in the return boolean logic code because it is optimzed out by webpack before the insertion.
+     * As workaround we wrap it in a function so that it is not optimized out.
+     */
+    const license = () => CKEDITOR_PRODUCTIVITY_LICENSE;
+    return window?.contextJsParameters?.valid && Boolean(license());
 };

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -60,9 +60,9 @@ export const set = (target, path, value) => {
 export const isProductivityMode = () => {
     /**
      * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
-     * We cannot use it directly in the return boolean logic code because it is optimzed out by webpack before the insertion.
-     * As workaround we wrap it in a function so that it is not optimized out.
+     * We cannot use it directly in the return boolean logic code because it is optimized out by webpack before the insertion.
+     * As workaround we call toString() function so that it is not optimized out.
      */
-    const license = () => CKEDITOR_PRODUCTIVITY_LICENSE;
-    return window?.contextJsParameters?.valid && Boolean(license());
+    // eslint-disable-next-line no-undef
+    return window?.contextJsParameters?.valid && Boolean(CKEDITOR_PRODUCTIVITY_LICENSE?.toString());
 };


### PR DESCRIPTION
### Description

[Last fix](https://github.com/Jahia/richtext-ckeditor5/pull/115) still not working due to optimization of webpack with the boolean condition logic. 

As workaround, add a call to `toString()` so that it is not optimized out by webpack and return the correct value.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
