### PR TITLE
fix: Revert productivity mode logic

### DIFF
--- a/src/javascript/CKEditor/JahiaClassicEditor.js
+++ b/src/javascript/CKEditor/JahiaClassicEditor.js
@@ -12,11 +12,11 @@ export class JahiaClassicEditor extends ClassicEditor {
     static create(sourceElementOrData, config = {}) {
         config = {...JahiaClassicEditor.defaultConfig, ...config};
 
-        if (isProductivityMode()) {
-            // eslint-disable-next-line no-undef
-            config.licenseKey = CKEDITOR_PRODUCTIVITY_LICENSE;
-        } else {
-            config.licenseKey = 'GPL';
+        const isProductivityEnabled = isProductivityMode();
+        // eslint-disable-next-line no-undef
+        config.licenseKey = isProductivityEnabled ? CKEDITOR_PRODUCTIVITY_LICENSE : 'GPL';
+
+        if (!isProductivityEnabled) {
             JahiaClassicEditor.builtinPlugins = JahiaClassicEditor.builtinPlugins
                 .filter(p => !p.isPremiumPlugin);
         }

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -57,12 +57,10 @@ export const set = (target, path, value) => {
     }
 };
 
-export const isProductivityMode = () => {
-    /**
-     * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
-     * We cannot use it directly in the return boolean logic code because it is optimized out by webpack before the insertion.
-     * As workaround we call toString() function so that it is not optimized out.
-     */
-    // eslint-disable-next-line no-undef
-    return window?.contextJsParameters?.valid && Boolean(CKEDITOR_PRODUCTIVITY_LICENSE?.toString());
-};
+/**
+ * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
+ * We cannot use it directly in the return boolean logic code because it is optimized out by webpack before the insertion.
+ * As workaround we call toString() function so that it is not optimized out.
+ */
+// eslint-disable-next-line
+export const isProductivityMode = () => window?.contextJsParameters?.valid && CKEDITOR_PRODUCTIVITY_LICENSE;


### PR DESCRIPTION
### Description

Workaround still not working with the latest built artifact in nexus (even though tests are ok and github artifacts are working locally).

Reverting to the old logic.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
