### PR TITLE
fix: Fix missing license in publish action

### DIFF
--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -103,6 +103,12 @@ jobs:
         password: ${{ secrets.DOCKERHUB_PASSWORD }}
     steps:
       - uses: actions/checkout@v4
+      - name: Create .env file
+        shell: bash
+        env:
+          CKEDITOR_PRODUCTIVITY_LICENSE: ${{ secrets.CKEDITOR_PRODUCTIVITY_LICENSE }}
+        run: |
+          echo "CKEDITOR_PRODUCTIVITY_LICENSE=${CKEDITOR_PRODUCTIVITY_LICENSE}" > .env
       - uses: jahia/jahia-modules-action/publish@v2
         with:
           nexus_username: ${{ secrets.NEXUS_USERNAME }}

--- a/src/javascript/CKEditor/JahiaClassicEditor.js
+++ b/src/javascript/CKEditor/JahiaClassicEditor.js
@@ -12,11 +12,11 @@ export class JahiaClassicEditor extends ClassicEditor {
     static create(sourceElementOrData, config = {}) {
         config = {...JahiaClassicEditor.defaultConfig, ...config};
 
-        const isProductivityEnabled = isProductivityMode();
-        // eslint-disable-next-line no-undef
-        config.licenseKey = isProductivityEnabled ? CKEDITOR_PRODUCTIVITY_LICENSE : 'GPL';
-
-        if (!isProductivityEnabled) {
+        if (isProductivityMode()) {
+            // eslint-disable-next-line no-undef
+            config.licenseKey = CKEDITOR_PRODUCTIVITY_LICENSE;
+        } else {
+            config.licenseKey = 'GPL';
             JahiaClassicEditor.builtinPlugins = JahiaClassicEditor.builtinPlugins
                 .filter(p => !p.isPremiumPlugin);
         }

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -57,10 +57,12 @@ export const set = (target, path, value) => {
     }
 };
 
-/**
- * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
- * We cannot use it directly in the return boolean logic code because it is optimized out by webpack before the insertion.
- * As workaround we call toString() function so that it is not optimized out.
- */
-// eslint-disable-next-line
-export const isProductivityMode = () => window?.contextJsParameters?.valid && CKEDITOR_PRODUCTIVITY_LICENSE;
+export const isProductivityMode = () => {
+    /**
+     * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.
+     * We cannot use it directly in the return boolean logic code because it is optimized out by webpack before the insertion.
+     * As workaround we call toString() function so that it is not optimized out.
+     */
+    // eslint-disable-next-line no-undef
+    return window?.contextJsParameters?.valid && Boolean(CKEDITOR_PRODUCTIVITY_LICENSE?.toString());
+};


### PR DESCRIPTION
### Description

Last revert was not needed, issue was not from the code (as it was passing tests on on-merge and PR tests) but that we are missing setting the env for the license during publish (the publish job does it's own build and is not the same artifact uploaded to github as the on uploaded to nexus, and needs to also have this set).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
