### PR TITLE
fix: CK5 configuration type changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-module-signature>MCwCFGPZA0Ni3xV4FZEnAGFPkl+ABsDzAhRFdmKzrUsdX4uVsWfCzEbykEg3qQ==</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
-        <jahia-depends>jcontent=3</jahia-depends>
+        <jahia-depends>jcontent=3.4</jahia-depends>
     </properties>
 
     <repositories>

--- a/src/javascript/CKEditor/configurations/config-default.js
+++ b/src/javascript/CKEditor/configurations/config-default.js
@@ -28,7 +28,9 @@ export const config = {
             'indent',
             'outdent'
         ],
-        shouldNotGroupWhenFull: false
+        // Set to true to wrap the toolbar items
+        // Set to false if we want to group items
+        shouldNotGroupWhenFull: true
     },
     menuBar: {
         isVisible: true

--- a/src/javascript/CKEditor/configurations/config-default.js
+++ b/src/javascript/CKEditor/configurations/config-default.js
@@ -4,10 +4,14 @@ export const config = {
     plugins,
     toolbar: {
         items: [
+            'undo',
+            'redo',
             'sourceEditing',
             'showBlocks',
+            'fullScreen',
             '|',
             'heading',
+            'style',
             '|',
             'bold',
             'italic',
@@ -20,6 +24,7 @@ export const config = {
             'insertTable',
             '|',
             'bulletedList',
+            'numberedList',
             'indent',
             'outdent'
         ],

--- a/src/javascript/CKEditor/configurations/toolbars.js
+++ b/src/javascript/CKEditor/configurations/toolbars.js
@@ -4,7 +4,7 @@ export const advancedToolbar = {
         'redo',
         'sourceEditing',
         'showBlocks',
-        'fullPage',
+        'fullScreen',
         '|',
         'heading',
         'style',
@@ -22,7 +22,10 @@ export const advancedToolbar = {
         'numberedList',
         'indent',
         'outdent'
-    ]
+    ],
+    menuBar: {
+        isVisible: false
+    }
 };
 
 export const lightToolbar = {
@@ -44,7 +47,10 @@ export const lightToolbar = {
         'numberedList',
         'indent',
         'outdent'
-    ]
+    ],
+    menuBar: {
+        isVisible: false
+    }
 };
 
 export const minimalToolbar = {
@@ -56,17 +62,22 @@ export const minimalToolbar = {
         'alignment:left',
         'alignment:center',
         'alignment:right'
-    ]
+    ],
+    menuBar: {
+        isVisible: false
+    }
 };
 
-export const resolveToolbar = type => {
-    if (type === 'Full') {
-        return advancedToolbar;
+export const resolveToolbar = () => {
+    const ck5config = contextJsParameters.config.ckeditor5;
+    switch (ck5config?.configType) {
+        case 'advanced':
+            return advancedToolbar;
+        case 'light':
+            return lightToolbar;
+        case 'minimal':
+            return minimalToolbar;
+        default:
+            return {}; // Return empty object to default to complete toolbar (default)
     }
-
-    if (type === 'Basic') {
-        return lightToolbar;
-    }
-
-    return minimalToolbar;
 };

--- a/src/javascript/CKEditor/configurations/toolbars.js
+++ b/src/javascript/CKEditor/configurations/toolbars.js
@@ -1,68 +1,78 @@
 export const advancedToolbar = {
-    toolbar: [
-        'undo',
-        'redo',
-        'sourceEditing',
-        'showBlocks',
-        'fullScreen',
-        '|',
-        'heading',
-        'style',
-        'bold',
-        'italic',
-        'removeFormat',
-        '|',
-        'alignment',
-        '|',
-        'jahiaInsertImage',
-        'jahiaLink',
-        'insertTable',
-        '|',
-        'bulletedList',
-        'numberedList',
-        'indent',
-        'outdent'
-    ],
+    toolbar: {
+        items: [
+            'undo',
+            'redo',
+            'sourceEditing',
+            'showBlocks',
+            'fullScreen',
+            '|',
+            'heading',
+            'style',
+            '|',
+            'bold',
+            'italic',
+            'removeFormat',
+            '|',
+            'alignment',
+            '|',
+            'jahiaInsertImage',
+            'jahiaLink',
+            'insertTable',
+            '|',
+            'bulletedList',
+            'numberedList',
+            'indent',
+            'outdent'
+        ],
+        shouldNotGroupWhenFull: true
+    },
     menuBar: {
         isVisible: false
     }
 };
 
 export const lightToolbar = {
-    toolbar: [
-        'undo',
-        'redo',
-        'heading',
-        'bold',
-        'italic',
-        'removeFormat',
-        '|',
-        'alignment',
-        '|',
-        'jahiaInsertImage',
-        'jahiaLink',
-        'insertTable',
-        '|',
-        'bulletedList',
-        'numberedList',
-        'indent',
-        'outdent'
-    ],
+    toolbar: {
+        items: [
+            'undo',
+            'redo',
+            'heading',
+            'bold',
+            'italic',
+            'removeFormat',
+            '|',
+            'alignment',
+            '|',
+            'jahiaInsertImage',
+            'jahiaLink',
+            'insertTable',
+            '|',
+            'bulletedList',
+            'numberedList',
+            'indent',
+            'outdent'
+        ],
+        shouldNotGroupWhenFull: true
+    },
     menuBar: {
         isVisible: false
     }
 };
 
 export const minimalToolbar = {
-    toolbar: [
-        'bold',
-        'italic',
-        'underline',
-        'removeFormat',
-        'alignment:left',
-        'alignment:center',
-        'alignment:right'
-    ],
+    toolbar: {
+        items: [
+            'bold',
+            'italic',
+            'underline',
+            'removeFormat',
+            'alignment:left',
+            'alignment:center',
+            'alignment:right'
+        ],
+        shouldNotGroupWhenFull: true
+    },
     menuBar: {
         isVisible: false
     }

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.jsx
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.jsx
@@ -52,6 +52,7 @@ export const RichTextCKEditor5 = ({field, id, value, onChange, onBlur}) => {
     }
 
     const customConfig = {
+        ...resolveToolbar(),
         ...parsedOptions.ckEditorConfig,
         language: uilang,
         picker: {
@@ -60,8 +61,7 @@ export const RichTextCKEditor5 = ({field, id, value, onChange, onBlur}) => {
             uilang,
             client,
             store
-        },
-        ...resolveToolbar(data.forms.ckeditorToolbar)
+        }
     };
 
     if (translations.length > 0) {

--- a/src/main/java/org/jahia/modules/ckeditor/config/RichtextConfig.java
+++ b/src/main/java/org/jahia/modules/ckeditor/config/RichtextConfig.java
@@ -21,9 +21,12 @@ public class RichtextConfig implements ManagedService {
     private final static String INCLUDE_SITES = "includeSites";
     private final static String EXCLUDE_SITES = "excludeSites";
     private final static String ENABLED_BY_DEFAULT = "enabledByDefault";
+    private final static String CONFIG_TYPE = "configType";
+
     private boolean enabledByDefault = false;
     private List<String> includeSites = new ArrayList<>();
     private List<String> excludeSites = new ArrayList<>();
+    private String configType = "complete";
 
     public RichtextConfig() {
         super();
@@ -34,6 +37,8 @@ public class RichtextConfig implements ManagedService {
         enabledByDefault = getBoolean(dictionary, ENABLED_BY_DEFAULT);
         includeSites = getList(dictionary, INCLUDE_SITES);
         excludeSites = getList(dictionary, EXCLUDE_SITES);
+        configType = (dictionary != null && dictionary.get(CONFIG_TYPE) != null)
+                ? dictionary.get(CONFIG_TYPE).toString() : "complete";
     }
 
     private boolean getBoolean(Dictionary<String, ?> properties, String key) {
@@ -67,6 +72,7 @@ public class RichtextConfig implements ManagedService {
         obj.put(ENABLED_BY_DEFAULT, enabledByDefault);
         obj.put(INCLUDE_SITES, new JSONArray(includeSites));
         obj.put(EXCLUDE_SITES, new JSONArray(excludeSites));
+        obj.put(CONFIG_TYPE, configType);
         return obj;
     }
 }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.cfg
@@ -1,5 +1,4 @@
 enabledByDefault=true
-configType=complete
 
 ## Possible usages and options
 #

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.cfg
@@ -1,4 +1,5 @@
 enabledByDefault=true
+configType=complete
 
 ## Possible usages and options
 #

--- a/src/main/resources/META-INF/patches/groovy/01-markExistingSites.started.groovy
+++ b/src/main/resources/META-INF/patches/groovy/01-markExistingSites.started.groovy
@@ -26,7 +26,7 @@ void excludeExistingSites() {
             def siteService = JahiaSitesService.getInstance();
             ConfigService configService = BundleUtils.getOsgiService(ConfigService.class, null);
             if (configService != null) {
-                Config config = configService.getConfig("org.jahia.modules.richtext-ckeditor5");
+                Config config = configService.getConfig("org.jahia.modules.richtext_ckeditor5");
                 PropertiesValues values = config.getValues();
                 values.setProperty("enabledByDefault", "true");
                 values.setProperty("excludeSites", siteService.getSitesNodeList(jcrSessionWrapper)

--- a/src/main/resources/configs/richtext-ckeditor5.jsp
+++ b/src/main/resources/configs/richtext-ckeditor5.jsp
@@ -2,4 +2,8 @@
 <%@ page import="org.jahia.osgi.BundleUtils"%>
 <%@ page language="java" contentType="text/javascript" %>
 
+<%
+  response.addHeader("Pragma", "no-cache");
+  response.setHeader("Cache-Control", "no-cache");
+%>
 contextJsParameters.config.ckeditor5 = <%= BundleUtils.getOsgiService(RichtextConfig.class, "(service.pid=org.jahia.modules.richtext_ckeditor5)").toJSON().toString() %>;


### PR DESCRIPTION
### Description

Collection of fixes to configurations

- Switch configuration type logic from using permissions to OSGi attribute `configType` (temporary)
- Add jahia-depends to latest jcontent 3.4-SN for required dependency fixes
- Match `complete` config toolbars to `advanced` config
- Remove menu bars for advanced, light and minimal config types
- Fix issue of multiple OSGi configs created (typo in migration script)
- Add no-cache directives for loading configs in js
- Switched to wrapping toolbars vs grouped


### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [x] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
