### PR TITLE
fix: Apply reset styling to all CK5 balloon toolbar

### DIFF
--- a/src/javascript/CKEditor/JahiaClassicEditor.js
+++ b/src/javascript/CKEditor/JahiaClassicEditor.js
@@ -6,7 +6,8 @@ import {ClassicEditor} from 'ckeditor5';
 import {isElement} from 'lodash-es';
 
 import 'ckeditor5/ckeditor5.css';
-import {isProductivityMode} from '../RichTextCKEditor5/RichTextCKEditor5.utils';
+import 'ckeditor5-premium-features/ckeditor5-premium-features.css';
+import {isProductivityMode} from '~/RichTextCKEditor5/RichTextCKEditor5.utils';
 
 export class JahiaClassicEditor extends ClassicEditor {
     static create(sourceElementOrData, config = {}) {

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -1,10 +1,14 @@
 :root {
-    --ck-z-default: 10555 !important;
-    --ck-z-modal: calc(var(--ck-z-default) + 999) !important;
+    --ck-z-default: 10555;
+    --ck-z-modal: calc(var(--ck-z-default) + 999);
 }
 
-.ck.ck-form.ck-link-form {
+/**
+ * Related to this global reset in anthracite
+ * https://github.com/Jahia/jahia-private/blob/master/war/src/main/webapp/engines/jahia-anthracite/css/components/_build.scss#L802
+ * Overriding with !important for now to ensure it takes precedence over the default anthracite styles
+ */
+.ck.ck-form {
     padding-bottom: 0 !important;
     width: var(--ck-link-panel-width) !important;
 }
-


### PR DESCRIPTION
### Description

Making the override from https://github.com/Jahia/richtext-ckeditor5/pull/138 more generic and apply to all CK5 toolbars (not just links), and also apply ck5 premium plugin stylings (import css).

There is also related PR to fix this in anthracite and exclude ck5 in the global stylings ([link](https://github.com/Jahia/jahia-private/pull/3745)) but will keep this for now so as we don't need core update for the fix.

Also removing `!important` for the z-index override as it doesn't seem needed.

### Checklist
#### Source code
- [x] I've shared and documented any breaking change
- [x] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
