### PR TITLE
feat: Embed image alignment styles

### DIFF
--- a/src/javascript/CKEditor/configurations/plugins-default.js
+++ b/src/javascript/CKEditor/configurations/plugins-default.js
@@ -51,7 +51,7 @@ import {
     Template
 } from 'ckeditor5-premium-features';
 import {Picker, InsertJahiaImage, JahiaLinkProvider} from '~/CKEditor/Picker';
-import {ImageResizeStyler} from '~/CKEditor/plugins';
+import {ImageStyleEmbed} from '~/CKEditor/plugins';
 
 export const plugins = [
     Alignment,
@@ -78,7 +78,7 @@ export const plugins = [
     Image,
     ImageCaption,
     ImageResize,
-    ImageResizeStyler,
+    ImageStyleEmbed,
     ImageStyle,
     ImageToolbar,
     ImageUpload,

--- a/src/javascript/CKEditor/plugins/ImageResizeStyler.js
+++ b/src/javascript/CKEditor/plugins/ImageResizeStyler.js
@@ -1,11 +1,11 @@
-import {ImageResizeEditing, Plugin} from 'ckeditor5';
+import {ImageResizeEditing, ImageStyleEditing, Plugin, Image, DataFilter} from 'ckeditor5';
 
 /**
  * Embeds the styles for the resized image.
  */
 export class ImageResizeStyler extends Plugin {
     static get requires() {
-        return [ImageResizeEditing];
+        return [Image, DataFilter, ImageResizeEditing, ImageStyleEditing];
     }
 
     static get pluginName() {
@@ -14,41 +14,117 @@ export class ImageResizeStyler extends Plugin {
 
     init() {
         const editor = this.editor;
+        this.dataFilter = editor.plugins.get(DataFilter);
 
-        editor.conversion.for('downcast').add(dispatcher => {
-            dispatcher.on('attribute:resizedWidth:imageBlock', setStyles);
-            dispatcher.on('attribute:resizedWidth:imageInline', setStyles);
+        // Parse any embedded float and width styling from a given element and convert it to ck5 model
+        // We do this for block <figure> and inline <img> elements
+        editor.conversion.for('upcast').add(dispatcher => {
+            dispatcher.on('element:figure', upcastFloat.bind(this));
+            dispatcher.on('element:img', upcastFloat.bind(this), {priority: 'low'});
+            dispatcher.on('element:img', upcastWidth.bind(this), {priority: 'low'});
         });
 
-        function setStyles(evt, data, conversionApi) {
-            let viewImage = conversionApi.mapper.toViewElement(data.item);
-            if (!viewImage) {
-                return;
-            }
+        // Function handlers to embed styling when changed in the model
+        editor.conversion.for('downcast').add(dispatcher => {
+            dispatcher.on('attribute:resizedWidth', setResizeStyles);
+            dispatcher.on('attribute:imageStyle', setAlignmentStyles);
+        });
+    }
+}
 
-            // ViewImage can sometimes be a container element and not the img element (in the case of imageBlock),
-            // so we need to find the img element within this container
-            let hasContainer = !viewImage.is('element', 'img');
-            if (hasContainer) {
-                viewImage = [...viewImage.getChildren()].find(c => c.is('element', 'img'));
-                if (!viewImage) {
-                    return;
-                }
-            }
+function upcastFloat(evt, data, conversionApi) {
+    const viewImage = data.viewItem;
+    const float = viewImage.getStyle('float');
 
-            if (data.attributeNewValue) {
-                // Image has been resized; embed styling
-                conversionApi.writer.setStyle('height', 'auto', viewImage);
-                if (hasContainer && !viewImage.getStyle('width')) {
-                    conversionApi.writer.setStyle('width', data.attributeNewValue, viewImage);
-                }
-            } else {
-                // Image has been restored to original values; remove styling
-                conversionApi.writer.removeStyle('height', viewImage);
-                if (hasContainer && viewImage.getStyle('width') === data.attributeOldValue) {
-                    conversionApi.writer.removeStyle('width', viewImage);
-                }
-            }
+    if (!float || !conversionApi.consumable.consume(viewImage, {style: 'float'})) {
+        return;
+    }
+
+    const modelElement = data.modelRange?.start.nodeAfter;
+    if (modelElement && conversionApi.schema.checkAttribute(modelElement, 'imageStyle')) {
+        this.dataFilter.processViewAttributes(viewImage, conversionApi);
+        // Set the imageStyle attribute based on the float value
+        const styleValues = {left: 'alignLeft', right: 'alignRight'};
+        if (styleValues[float]) {
+            conversionApi.writer.setAttribute('imageStyle', styleValues[float], modelElement);
         }
     }
+}
+
+function upcastWidth(evt, data, conversionApi) {
+    const viewImage = data.viewItem;
+    const width = viewImage.getStyle('width');
+
+    if (!width || !conversionApi.consumable.consume(viewImage, {style: 'width'})) {
+        return;
+    }
+
+    const modelElement = data.modelRange?.start.nodeAfter;
+    if (modelElement && conversionApi.schema.checkAttribute(modelElement, 'resizedWidth')) {
+        this.dataFilter.processViewAttributes(viewImage, conversionApi);
+        conversionApi.writer.setAttribute('resizedHeight', 'auto', modelElement);
+        conversionApi.writer.setAttribute('resizedWidth', width, modelElement);
+    }
+}
+
+function setResizeStyles(evt, data, conversionApi) {
+    const {viewImage, hasContainer} = getViewImage(data, conversionApi);
+    if (!viewImage) {
+        return;
+    }
+
+    if (data.attributeNewValue) {
+        // Image has been resized; embed styling
+        console.debug(`Applying width style '${data.attributeNewValue}' for ${viewImage.name}`);
+        conversionApi.writer.setStyle('height', 'auto', viewImage);
+        if (hasContainer && !viewImage.getStyle('width')) {
+            conversionApi.writer.setStyle('width', data.attributeNewValue, viewImage);
+        }
+    } else {
+        // Image has been restored to original values; remove styling
+        conversionApi.writer.removeStyle('height', viewImage);
+        if (hasContainer && viewImage.getStyle('width') === data.attributeOldValue) {
+            conversionApi.writer.removeStyle('width', viewImage);
+        }
+    }
+}
+
+function setAlignmentStyles(evt, data, conversionApi) {
+    const viewImage = conversionApi.mapper.toViewElement(data.item);
+    if (!viewImage) {
+        return;
+    }
+
+    conversionApi.writer.setStyle('float', null, viewImage);
+    conversionApi.writer.removeStyle('float', viewImage);
+
+    if (data.attributeNewValue) {
+        const floatStyles = Object.freeze({
+            alignLeft: 'left',
+            alignRight: 'right'
+        });
+        const floatDir = floatStyles[data.attributeNewValue];
+        if (floatDir) {
+            console.debug(`Applying alignment style 'float:${floatDir}' for ${viewImage.name}`);
+            conversionApi.writer.setStyle('float', floatDir, viewImage);
+        }
+    }
+}
+
+function getViewImage(data, conversionApi) {
+    let viewImage = conversionApi.mapper.toViewElement(data.item);
+    if (!viewImage) {
+        return null;
+    }
+
+    // ViewImage can sometimes be a container element and not the img element (in the case of imageBlock),
+    // so we need to find the img element within this container
+    let hasContainer = !viewImage.is('element', 'img');
+    let viewContainer = null;
+    if (hasContainer) {
+        viewContainer = viewImage;
+        viewImage = [...viewImage.getChildren()].find(c => c.is('element', 'img'));
+    }
+
+    return {viewImage, viewContainer, hasContainer};
 }

--- a/src/javascript/CKEditor/plugins/ImageStyleEmbed.js
+++ b/src/javascript/CKEditor/plugins/ImageStyleEmbed.js
@@ -3,13 +3,13 @@ import {ImageResizeEditing, ImageStyleEditing, Plugin, Image, DataFilter} from '
 /**
  * Embeds the styles for the resized image.
  */
-export class ImageResizeStyler extends Plugin {
+export class ImageStyleEmbed extends Plugin {
     static get requires() {
         return [Image, DataFilter, ImageResizeEditing, ImageStyleEditing];
     }
 
     static get pluginName() {
-        return 'ImageResizeStyler';
+        return 'ImageStyleEmbed';
     }
 
     init() {

--- a/src/javascript/CKEditor/plugins/index.js
+++ b/src/javascript/CKEditor/plugins/index.js
@@ -1,1 +1,1 @@
-export {ImageResizeStyler} from './ImageResizeStyler';
+export {ImageStyleEmbed} from './ImageStyleEmbed';

--- a/tests/cypress.config.common.ts
+++ b/tests/cypress.config.common.ts
@@ -17,7 +17,7 @@ export const baseConfig = {
     viewportHeight: 768,
     watchForFileChanges: false,
     experimentalMemoryManagement: true,
-    numTestsKeptInMemory: 20,
+    numTestsKeptInMemory: 1,
     e2e: {
         specPattern: ['**/**.cy.ts'],
         // We've imported your old cypress plugins here.

--- a/tests/cypress/e2e/imagePicker.cy.ts
+++ b/tests/cypress/e2e/imagePicker.cy.ts
@@ -3,7 +3,7 @@ import {Picker} from '@jahia/jcontent-cypress/dist/page-object/picker';
 import {createSite, deleteSite, getComponentByRole, uploadFile} from '@jahia/cypress';
 import {Ckeditor5, RichTextCKeditor5Field} from '../page-object/ckeditor5';
 
-describe('Insert image tests', () => {
+describe('Image picker tests', () => {
     const siteKey = 'imageCKEditor5Site';
     const ckeditor5 = new Ckeditor5();
 


### PR DESCRIPTION
### Description

Add event handler for when alignment styles are applied (`attribute:imageStyle`) to embed float styles directly to the element.

We also need to add upcast functions to parse existing rich text data when float and image resize styling is already applied to an image for both block (figure) and inline (img) elements.

Added cypress test for left and right alignment

### Checklist
#### Source code
- ~[ ] I've shared and documented any breaking change~
- ~[ ] I've reviewed and updated the jahia-depends~

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
