### PR TITLE
fix: Use editorial link picker for inserting links

### DIFF
--- a/src/javascript/CKEditor/Picker/JahiaLinkProvider.js
+++ b/src/javascript/CKEditor/Picker/JahiaLinkProvider.js
@@ -42,6 +42,7 @@ export class JahiaLinkProvider extends Plugin {
                 const url = `${contentPrefix}${pickerResults[0].path}.html`;
                 editor.execute('link', url);
             },
+            type: 'editoriallink',
             ...pickerConfig
         });
     }


### PR DESCRIPTION
### Description

Change picker type when inserting Jahia links to only show displayable types i.e. use `editoriallink` picker, same picker used in CK4.

![image](https://github.com/user-attachments/assets/6dbbca15-edbd-4e2a-8521-68aa65935207)

