### PR TITLE
feat: Add default protocol when inserting links

### DIFF
--- a/src/javascript/CKEditor/configurations/config-default.js
+++ b/src/javascript/CKEditor/configurations/config-default.js
@@ -132,6 +132,7 @@ export const config = {
     },
     link: {
         toolbar: ['editLink', 'linkProperties', 'unlink'],
+        defaultProtocol: 'https://',
         decorators: {
             openInNewTab: {
                 mode: 'manual',


### PR DESCRIPTION
### Description

Enable `https://` as default protocol to add automatically when inserting links: https://ckeditor.com/docs/ckeditor5/latest/features/link.html#adding-default-link-protocol-to-external-links

This also adds email auto-detection feature (auto insert `mailto://` when it detects email address).

Users should still be able to override if protocol is specified when inserting links.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
