### PR TITLE
feat: embed align center styling for images

### DIFF
--- a/src/javascript/CKEditor/configurations/config-complete.js
+++ b/src/javascript/CKEditor/configurations/config-complete.js
@@ -97,7 +97,7 @@ export const completeConfig = {
             'imageTextAlternative',
             '|',
             'imageStyle:inline',
-            'imageStyle:block',
+            'imageStyle:alignCenter',
             'imageStyle:wrapText',
             '|',
             'resizeImage:original',

--- a/tests/cypress/e2e/image.cy.ts
+++ b/tests/cypress/e2e/image.cy.ts
@@ -125,6 +125,29 @@ describe('Image tests', () => {
         testAlign('Right');
     });
 
+    it('should be able to center align and display in page builder', () => {
+        const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
+            .switchToListMode();
+        const ce = jcontent.editComponentByText('Lorem ipsum');
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+
+        // Trigger the balloon toolbar for images
+        // Ensure the image content is loaded before click
+        ck5field.getEditArea().find('img').should('be.visible').click('center');
+        ck5field.getBalloonToolbarButton('Centered image').click();
+
+        ck5field.getEditArea().find('.image-style-align-center') // Verify classes added by ck5
+            .invoke('attr', 'style')
+            .should('contain', 'text-align:center');
+        ce.save();
+
+        // // Verify image is also resized in page builder
+        const pb = jcontent.switchToPageBuilder();
+        pb.getModule(`/sites/${siteKey}/home/area-main/${textName}`).get().find('.image-style-align-center')
+            .invoke('attr', 'style')
+            .should('contain', 'text-align:center');
+    });
+
     function testAlign(alignment: 'Left' | 'Right') {
         const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
             .switchToListMode();


### PR DESCRIPTION
### Description

Add upcast/downcast converters for setting center align in images:

- set `imageStyle` attribute in ck5 model when `text-align: center` is present in image element
- set/remove `text-align: center` for image elements when centered image is clicked in the image toolbar

Added cypress test

### Checklist
#### Source code
- ~[ ] I've shared and documented any breaking change~
- ~[ ] I've reviewed and updated the jahia-depends~

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [x] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
