### PR TITLE
fix: show popups when CK is fullscreen

### DIFF
--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -1,6 +1,7 @@
-:root {
+:root, body.ck-fullscreen {
     --ck-z-default: 10555;
     --ck-z-modal: calc(var(--ck-z-default) + 999);
+    --ck-z-fullscreen: 1300;
 }
 
 /**


### PR DESCRIPTION
### Description
This PR changes the index of CK's fullscreen panel so jahia pickers are visible.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
