### PR TITLE
fix: disable insert image tool when CK is read only

### DIFF
--- a/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImage.js
+++ b/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImage.js
@@ -61,6 +61,8 @@ export class InsertJahiaImage extends Plugin {
                 icon: imageIcon
             });
 
+            view.bind('isEnabled').to(editor, 'isReadOnly', isReadOnly => !isReadOnly);
+
             view.on('execute', () => {
                 editor.commands.execute('jahiaInsertImageCommand');
             });
@@ -77,6 +79,8 @@ export class InsertJahiaImage extends Plugin {
                 withText: false,
                 icon: imageIcon
             });
+
+            view.bind('isEnabled').to(editor, 'isReadOnly', isReadOnly => !isReadOnly);
 
             view.on('execute', () => {
                 editor.commands.execute('jahiaInsertImageCommand');


### PR DESCRIPTION
### Description
This PR makes the insert image icon disabled when editor is in read only mode.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
