### PR TITLE
fix: Enable editor by default

### DIFF
--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.yml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtext_ckeditor5.yml
@@ -1,7 +1,7 @@
 # default configuration
 ## Possible usages and options
 #
-#enabledByDefault: true
+enabledByDefault: true
 #configs:
 ##  Will apply first available/matching config, permission is optional
 #  - siteKeys:


### PR DESCRIPTION
### Description
Enable editor by default, restore previous behaviour.
### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
