### PR TITLE
fix: Fix centering when image width is specified

### DIFF
--- a/src/javascript/CKEditor/plugins/ImageStyleEmbed.js
+++ b/src/javascript/CKEditor/plugins/ImageStyleEmbed.js
@@ -138,10 +138,14 @@ function setAlignStyles(evt, data, conversionApi) {
     console.debug(`Removing alignment style 'text-align:center' for ${viewImage.name}`);
     conversionApi.writer.setStyle('text-align', null, viewImage);
     conversionApi.writer.removeStyle('text-align', viewImage);
+    if (viewImage.getStyle('margin') === 'auto') {
+        conversionApi.writer.removeStyle('margin', viewImage);
+    }
 
     if (data.attributeNewValue === 'alignCenter') {
         console.debug(`Applying alignment style 'text-align:center' for ${viewImage.name}`);
         conversionApi.writer.setStyle('text-align', 'center', viewImage);
+        conversionApi.writer.setStyle('margin', 'auto', viewImage);
     }
 }
 


### PR DESCRIPTION
### Description

`text-align: center` is not enough to center when width is specified in the element.

Add `margin: auto` to override.
