### PR TITLE
fix: add height to body to fix menus in fullscreen

### DIFF
--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -4,6 +4,11 @@
     --ck-z-fullscreen: 1300;
 }
 
+body.ck-fullscreen {
+    /* Without this, body has height 0 in fullscreen mode in firefox */
+    min-height: 100%;
+}
+
 /**
  * Related to this global reset in anthracite
  * https://github.com/Jahia/jahia-private/blob/master/war/src/main/webapp/engines/jahia-anthracite/css/components/_build.scss#L802


### PR DESCRIPTION
### Description
This PR adds min height to body element in CK fullscreen. For some reason, it shows up as zero without this (on Firefox only)

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
