### PR TITLE
fix: preselect link in link picker

### DIFF
--- a/tests/cypress/e2e/link.cy.ts
+++ b/tests/cypress/e2e/link.cy.ts
@@ -3,6 +3,14 @@ import {Picker} from '@jahia/jcontent-cypress/dist/page-object/picker';
 import {addNode, createSite, deleteSite, getComponentByAttr} from '@jahia/cypress';
 import {Ckeditor5, RichTextCKeditor5Field} from '../page-object/ckeditor5';
 
+const openLinkPicker = ck5field => {
+    // Workaround to trigger the balloon toolbar for links
+    ck5field.getEditArea().type('{leftArrow}{leftArrow}{leftArrow}', {delay: 300});
+    ck5field.clickMenuItemByLabel('Insert');
+    ck5field.getMenuSubItemByLabel('Link').click();
+    ck5field.getBalloonToolbarButton('Back').click();
+};
+
 describe('Link tests', () => {
     const siteKey = 'linkCKEditor5Site';
     const ckeditor5 = new Ckeditor5();
@@ -42,11 +50,7 @@ describe('Link tests', () => {
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.getEditArea().contains('my text').click('center');
 
-        // Workaround to trigger the balloon toolbar for links
-        ck5field.getEditArea().type('{leftArrow}{leftArrow}{leftArrow}', {delay: 300});
-        ck5field.clickMenuItemByLabel('Insert');
-        ck5field.getMenuSubItemByLabel('Link').click();
-        ck5field.getBalloonToolbarButton('Back').click();
+        openLinkPicker(ck5field);
 
         ck5field.getBalloonToolbarButton('Link properties').should('be.visible').click();
 
@@ -70,11 +74,7 @@ describe('Link tests', () => {
         const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
         ck5field.getEditArea().contains('my text').click('center');
 
-        // Workaround to trigger the balloon toolbar for links
-        ck5field.getEditArea().type('{leftArrow}{leftArrow}{leftArrow}', {delay: 300});
-        ck5field.clickMenuItemByLabel('Insert');
-        ck5field.getMenuSubItemByLabel('Link').click();
-        ck5field.getBalloonToolbarButton('Back').click();
+        openLinkPicker(ck5field);
 
         ck5field.getBalloonToolbarButton('Edit link').should('be.visible').click();
         ck5field.getBalloonButton('Jahia internal links').should('be.visible').click();
@@ -82,5 +82,28 @@ describe('Link tests', () => {
         const picker = getComponentByAttr(Picker, 'data-sel-role', 'picker-dialog');
         picker.getTable().getRowByName(linkTargetName).get().click();
         picker.select();
+    });
+
+    it('should pre select link in picker', () => {
+        JContent.visit(siteKey, 'en', `content-folders/contents/${textName}`).editContent();
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+        ck5field.getEditArea().contains('my text').click('center');
+
+        openLinkPicker(ck5field);
+
+        ck5field.getBalloonToolbarButton('Edit link').should('be.visible').click();
+        ck5field.getBalloonButton('Jahia internal links').should('be.visible').click();
+
+        let picker = getComponentByAttr(Picker, 'data-sel-role', 'picker-dialog');
+        picker.getTable().getRowByName(linkTargetName).get().click();
+        picker.select();
+
+        openLinkPicker(ck5field);
+
+        ck5field.getBalloonToolbarButton('Edit link').should('be.visible').click();
+        ck5field.getBalloonButton('Jahia internal links').should('be.visible').click();
+
+        picker = getComponentByAttr(Picker, 'data-sel-role', 'picker-dialog');
+        picker.getTable().getRowByName(linkTargetName).get().should('have.class', 'moonstone-TableRow-highlighted');
     });
 });


### PR DESCRIPTION
### Description
This PR adds the feature of highlighting the link in link picker if it is originally from there (mimics CK4 experience).

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
