### PR TITLE
chore: Insert secret directly as env var into release reusable workflow

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -46,6 +46,9 @@ jobs:
           CKEDITOR_PRODUCTIVITY_LICENSE: ${{ secrets.CKEDITOR_PRODUCTIVITY_LICENSE }}
         run: |
           echo "CKEDITOR_PRODUCTIVITY_LICENSE=${CKEDITOR_PRODUCTIVITY_LICENSE}" > .env
+          echo "Env var is set? $([ -n "$CKEDITOR_PRODUCTIVITY_LICENSE" ] && echo 'Yes' || echo 'No')"
+          echo "Env var length: ${#CKEDITOR_PRODUCTIVITY_LICENSE}"
+          echo "CKEDITOR_PRODUCTIVITY_LICENSE exists in .env? $(grep -q CKEDITOR_PRODUCTIVITY_LICENSE .env && echo 'Yes' || echo 'No')"
 
       - uses: jahia/jahia-modules-action/release@v2
         name: Release Module

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -49,6 +49,8 @@ jobs:
 
       - uses: jahia/jahia-modules-action/release@v2
         name: Release Module
+        env:
+          CKEDITOR_PRODUCTIVITY_LICENSE: ${{ secrets.CKEDITOR_PRODUCTIVITY_LICENSE }}
         with:
           github_slug: Jahia/richtext-ckeditor5
           primary_release_branch: main


### PR DESCRIPTION
### Description

The created .env doesn't seem to be getting picked up during release.
Go the env var route instead and see if this gets picked up by webpack.

Also add some logging to see status of .env file and env var before running release step