### PR TITLE
chore: Update jahia-depends for jcontent version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <jahia-module-type>system</jahia-module-type>
         <jahia-module-signature>MCwCFDFBNZqHZlCsprvnzY3FNlCtgOFSAhQxjl4nWCpeEOkvv3EIDAj6cN3rWg==</jahia-module-signature>
         <yarn.arguments>build:production</yarn.arguments>
-        <jahia-depends>jcontent=3.4,graphql-dxm-provider</jahia-depends>
+        <jahia-depends>jcontent=3.4.1,graphql-dxm-provider</jahia-depends>
         <import-package>
             org.jahia.modules.contenteditor.graphql.api
         </import-package>


### PR DESCRIPTION
### Description
Update jcontent dependency to at least v2.4.1 for the graphql change [here](https://github.com/Jahia/richtext-ckeditor5/pull/222)

