### PR TITLE
chore: Fix test submodule version

### DIFF
--- a/tests/jahia-module/test-ckeditor5-config/pom.xml
+++ b/tests/jahia-module/test-ckeditor5-config/pom.xml
@@ -50,14 +50,14 @@
                       http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <artifactId>jahia-modules</artifactId>
-        <groupId>org.jahia.modules</groupId>
-        <version>8.2.0.0</version>
+        <groupId>org.jahia.test</groupId>
+        <artifactId>ckeditor5-test-module-root</artifactId>
+        <version>1.0.0-beta-1-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>
     <artifactId>test-ckeditor5-config</artifactId>
     <name>test-ckeditor5-config</name>
-    <version>1.0.0-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (test-ckeditor5-config) for running on a Jahia server.</description>
 


### PR DESCRIPTION
### Description

Fix submodule versioning by inheriting from parent

Taken from a recent PR fix in jcontent https://github.com/Jahia/jcontent/pull/1892