### PR TITLE
fix: expose ck5 packages in the module federation

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,6 +132,15 @@ module.exports = (env, argv) => {
                 remotes: {
                     '@jahia/jcontent': 'appShell.remotes.jcontent',
                 },
+                shared: {
+                    'ckeditor5': { singleton: true },
+                    '@ckeditor/ckeditor5-ui': { singleton: true },
+                    '@ckeditor/ckeditor5-core': { singleton: true },
+                    '@ckeditor/ckeditor5-react': { singleton: true },
+                    '@ckeditor/ckeditor5-utils': { singleton: true },
+                    'ckeditor5-premium-features': { singleton: true },
+                    '@ckeditor/ckeditor5-theme-lark': { singleton: true },
+                },
             })),
             new CleanWebpackPlugin({
                 cleanOnceBeforeBuildPatterns: [`${path.resolve(__dirname, 'src/main/resources/javascript/apps/')}/**/*`],


### PR DESCRIPTION
### Description

This might be enough to close #230, I'll QA it during https://github.com/Jahia/gautier-braindump/issues/46

The broken test is unrelated https://github.com/Jahia/richtext-ckeditor5/actions/runs/19689858419/job/56403207241#step:6:2209

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
