### PR TITLE
feat: Remove max-height to let the richtext fit the content height

### DIFF
--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
@@ -5,7 +5,6 @@
 .wrapper {
   overflow-y: scroll;
   min-height: 20vh;
-  max-height: 40vh;
 }
 
 


### PR DESCRIPTION
### Description
- Remove the `max-height` from the richText so the selector fits the content height.

Context: this has been added previously as part of this PR https://github.com/Jahia/richtext-ckeditor5/pull/53

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
