### PR TITLE
fix: Prevent z-index collision with moonstone components

### DIFF
--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -99,7 +99,7 @@ body.ck-fullscreen {
 .ck.ck-editor__top:has(~ .ck-editor__main .ck-focused) {
   position: sticky;
   top: 40px; /* size of the sticky section header */
-  z-index: 50; /* manage menu z-index when the toolbar is sticky */
+  z-index: 10; /* manage menu z-index when the toolbar is sticky */
 }
 
 /* Reset the fixed position from CKEditor */

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
@@ -2,6 +2,15 @@
 // Styles related to our CKEditor5 implementation
 //--
 
+// Moonstone fixes to remove when https://github.com/Jahia/moonstone/issues/1275 will be released an used in the product
+:global(.moonstone-collapsible_button_expanded) {
+  z-index: unset;
+}
+
+:global(.moonstone-collapsible_button_sticky) {
+  z-index: 100;
+}
+
 .wrapper {
   overflow-y: scroll;
   min-height: 20vh;


### PR DESCRIPTION
### Description
Fix `z-index` issue because of the `Collapsible` moonstone component.

⚠️ This fix should be reverted when the [moonstone issue](https://github.com/Jahia/moonstone/issues/1275) is released and used in the product.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
