### PR TITLE
test: bump @jahia/cypress from 4.0.0 to 4.5.0 and removed jahia-reporter

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -22,7 +22,7 @@
   "license": "MIT",
   "devDependencies": {
     "@4tw/cypress-drag-drop": "^2.2.1",
-    "@jahia/cypress": "^4.0.0",
+    "@jahia/cypress": "^4.5.0",
     "@jahia/jahia-reporter": "^1.0.30",
     "@jahia/jcontent-cypress": "^3.4.0-tests.3",
     "@types/node": "^18.11.18",

--- a/tests/yarn.lock
+++ b/tests/yarn.lock
@@ -120,10 +120,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
   integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
-"@jahia/cypress@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-4.0.0.tgz#d47b4b013c5f26bf969caf652c426a9a780b225d"
-  integrity sha512-rvG0NpB6RddUOcEr2JS9S3s3E0wdzUv1BtaTekLBsT8sW1wv/CfDiIQQxG3dwaS/JpTon4eGK6VyrPEUuT4xGQ==
+"@jahia/cypress@^4.5.0":
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/@jahia/cypress/-/cypress-4.5.0.tgz#0bdf76d0b4a9571065f5800aff52d277183edabd"
+  integrity sha512-2DKhUP/68AOQ+4dHUBdJPbVbMD8JgUaHTcBpS2ZBzC4oLfQAckFJPuX/itr4IusuziX2M6CuOjmR2rsHYGWU6g==
   dependencies:
     "@apollo/client" "^3.4.9"
     cypress-real-events "^1.11.0"


### PR DESCRIPTION
This is needed to build with a more recent Cypress docker image.