### PR TITLE
fix: Update Nexus Maven plugin version to 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
     </parent>
     <artifactId>richtext-ckeditor5</artifactId>
     <name>RichText CKEditor5</name>
-    <version>1.0.0-beta-2</version>
+    <version>1.0.0-beta-2-SNAPSHOT</version>
     <packaging>bundle</packaging>
     <description>This is the custom module (richtext-ckeditor5) for running on a Jahia server.</description>
 
@@ -41,7 +41,7 @@
         <connection>scm:git:https://github.com/Jahia/richtext-ckeditor5</connection>
         <developerConnection>scm:git:git@github.com:Jahia/richtext-ckeditor5.git</developerConnection>
         <url>https://github.com/Jahia/richtext-ckeditor5</url>
-        <tag>1_0_0-beta-2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>


### PR DESCRIPTION
We're getting this error during `mvn release:perform`:
```
[INFO] [ERROR] Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy (injected-nexus-deploy) on project richtext-ckeditor5: Execution injected-nexus-deploy of goal org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy failed: An API incompatibility was encountered while executing org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1:deploy: java.lang.ExceptionInInitializerError: null
[INFO] [ERROR] -----------------------------------------------------
[INFO] [ERROR] realm =    extension>org.sonatype.plugins:nexus-staging-maven-plugin:1.5.1
[INFO] [ERROR] strategy = org.codehaus.plexus.classworlds.strategy.SelfFirstStrategy
```

### Description
...

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
