### PR TITLE
chore: Adjust dev SNAPSHOT version for test module

### DIFF
--- a/.github/workflows/on-code-change.yml
+++ b/.github/workflows/on-code-change.yml
@@ -79,6 +79,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
+      - uses: s4u/setup-maven-action@v1.19.0
+        with:
+          java-distribution: 'temurin'
+          java-version: 11
       - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:

--- a/.github/workflows/on-merge.yml
+++ b/.github/workflows/on-merge.yml
@@ -56,6 +56,10 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 'lts/*'
+      - uses: s4u/setup-maven-action@v1.19.0
+        with:
+          java-distribution: 'temurin'
+          java-version: 11
       - uses: actions/checkout@v4
       - uses: jahia/jahia-modules-action/integration-tests@v2
         with:

--- a/tests/cypress/e2e/image.cy.ts
+++ b/tests/cypress/e2e/image.cy.ts
@@ -89,7 +89,7 @@ describe('Image tests', () => {
             .should('contain', linkUrl);
     });
 
-    it('should be able to resize image and display in page builder', () => {
+    it('should be able to resize image and display in page builder', {retries: 3}, () => {
         const jcontent = JContent.visit(siteKey, 'en', 'pages/home')
             .switchToListMode();
         const ce = jcontent.editComponentByText('Lorem ipsum');

--- a/tests/jahia-module/pom.xml
+++ b/tests/jahia-module/pom.xml
@@ -48,7 +48,7 @@
     <groupId>org.jahia.test</groupId>
     <artifactId>ckeditor5-test-module-root</artifactId>
     <name>CKEditor5 Test Module Root</name>
-    <version>1.0.0</version>
+    <version>1.0.0-beta-3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>This is the custom module for testing CKEditor 5 in Jahia</description>
 

--- a/tests/jahia-module/test-ckeditor5-config/pom.xml
+++ b/tests/jahia-module/test-ckeditor5-config/pom.xml
@@ -52,7 +52,7 @@
     <parent>
         <groupId>org.jahia.test</groupId>
         <artifactId>ckeditor5-test-module-root</artifactId>
-        <version>1.0.0</version>
+        <version>1.0.0-beta-3-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>org.jahia.test</groupId>

--- a/tests/provisioning-manifest-build.yml
+++ b/tests/provisioning-manifest-build.yml
@@ -25,6 +25,5 @@
     - 'mvn:org.jahia.modules/skins'
     - 'mvn:org.jahia.modules/default-skins'
     - 'mvn:org.jahia.modules/jcontent'
-    - 'mvn:org.jahia.test/test-ckeditor5-config'
   autoStart: true
   uninstallPreviousVersion: true


### PR DESCRIPTION
### Description

After release, need to make sure test modules have -SNAPSHOT.

Also, adjusted on-code-change workflow to build and use test-module, and not from a built artifact. 

There was also an issue of missing mvn when executing ci.build.sh so need to setup mvn in the integration tests step.

Also adjusted flaky image test with retries

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
