### PR TITLE
fix: max height for the wrapper

### DIFF
--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
@@ -14,6 +14,7 @@
 .wrapper {
   overflow-y: scroll;
   min-height: 20vh;
+  max-height: 25vh;
 }
 
 


### PR DESCRIPTION
### Description

Max height set for the ckeditor5 wrapper

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
