### PR TITLE
fix: Update default z-index of ck to 1

### DIFF
--- a/.chachalog/Oe9qPtqU.md
+++ b/.chachalog/Oe9qPtqU.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Update default z-index of ck to 1 (#292)

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -50,7 +50,7 @@
 
 :root,
 body.ck-fullscreen {
-    --ck-z-default: 1;
+    --ck-z-default: 1000;
     --ck-z-modal: calc(var(--ck-z-default) + 999);
     --ck-z-fullscreen: 1300;
 }

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5-overrides.css
@@ -50,7 +50,7 @@
 
 :root,
 body.ck-fullscreen {
-    --ck-z-default: 10555;
+    --ck-z-default: 1;
     --ck-z-modal: calc(var(--ck-z-default) + 999);
     --ck-z-fullscreen: 1300;
 }


### PR DESCRIPTION
### Description
Update default z-index of ck to 1000 so that it does not interfere with moonstone components. 

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
