### PR TITLE
chore: Remove references to deprecated methods

### DIFF
--- a/.chachalog/nUXDNXgZ.md
+++ b/.chachalog/nUXDNXgZ.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Remove references to deprecated methods (#297)

--- a/src/javascript/CKEditor/JahiaClassicEditor.js
+++ b/src/javascript/CKEditor/JahiaClassicEditor.js
@@ -11,15 +11,12 @@ import {removePlugin, removeToolbarItems} from '~/CKEditor/config.utils';
 
 export class JahiaClassicEditor extends ClassicEditor {
     static create(sourceElementOrData, config = {}) {
-        config = {...JahiaClassicEditor.defaultConfig, ...config};
-
         if (isProductivityMode()) {
             // eslint-disable-next-line no-undef
             config.licenseKey = CKEDITOR_PRODUCTIVITY_LICENSE;
         } else {
+            console.debug('Productivity mode not enabled');
             config.licenseKey = 'GPL';
-            JahiaClassicEditor.builtinPlugins = JahiaClassicEditor.builtinPlugins
-                .filter(p => !p.isPremiumPlugin);
         }
 
         // Remove Templates plugin, toolbar item if no definitions

--- a/src/javascript/CKEditor/registerConfig.js
+++ b/src/javascript/CKEditor/registerConfig.js
@@ -1,5 +1,4 @@
 import {registry} from '@jahia/ui-extender';
-import {JahiaClassicEditor} from '~/CKEditor/JahiaClassicEditor';
 import {completeConfig, minimalConfig, lightConfig, advancedConfig} from '~/CKEditor/configurations';
 import {REGISTRY_KEY} from '~/RichTextCKEditor5.constants';
 
@@ -8,8 +7,4 @@ export function registerConfig() {
     registry.addOrReplace(REGISTRY_KEY, 'advanced', advancedConfig);
     registry.addOrReplace(REGISTRY_KEY, 'light', lightConfig);
     registry.addOrReplace(REGISTRY_KEY, 'minimal', minimalConfig);
-
-    JahiaClassicEditor.builtinPlugins = minimalConfig.plugins;
-    JahiaClassicEditor.defaultConfig = minimalConfig;
 }
-

--- a/src/javascript/init.js
+++ b/src/javascript/init.js
@@ -2,7 +2,7 @@ import {registry} from '@jahia/ui-extender';
 import {registerRichTextCKEditor5} from './RichTextCKEditor5/registerRichTextCKEditor5';
 import {registerConfig} from '~/CKEditor/registerConfig';
 
-export default function () {
+export default function ck5RegistryInit() {
     registry.add('callback', 'richtext-ckeditor5', {
         targets: ['jahiaApp-init:50'],
         callback: registerRichTextCKEditor5


### PR DESCRIPTION
### Description

Remove references to Editor methods `builtinPlugins` and `defineConfig` as they are not needed anymore.

Should already be tested by existing configuration tests.
