### PR TITLE
fix: Properly refresh image command

### DIFF
--- a/.chachalog/UuKB-gi0.md
+++ b/.chachalog/UuKB-gi0.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Properly refresh image command (#298)

--- a/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImageCommand.js
+++ b/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImageCommand.js
@@ -4,22 +4,19 @@ export class InsertJahiaImageCommand extends Command {
     constructor(editor, type) {
         super(editor);
         this.type = type;
-
-        this.isEnabled = true;
-
-        // // Remove default document listener to lower its priority.
-        // this.stopListening(this.editor.model.document, 'change');
-        //
-        // // Lower this command listener priority to be sure that refresh() will be called after link & image refresh.
-        // this.listenTo(this.editor.model.document, 'change', () => this.refresh(), {priority: 'low'});
     }
 
     refresh() {
-        //
+        const imageInsertCommand = this.editor.commands.get('imageInsert');
+        this.isEnabled = imageInsertCommand ? imageInsertCommand.isEnabled : false;
     }
 
     execute() {
         const editor = this.editor;
+
+        if (!this.isEnabled) {
+            return;
+        }
 
         const pickerConfig = editor.config.get('picker');
 


### PR DESCRIPTION
### Description
Properly refresh image command so when edit source button changes context the plugin is still active.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
