### PR TITLE
fix: Use choicelist values for macros

### DIFF
--- a/.chachalog/uBy65qU5.md
+++ b/.chachalog/uBy65qU5.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Use choicelist values for macros (#301)

--- a/src/javascript/CKEditor/configurations/mention/mentionConfig.js
+++ b/src/javascript/CKEditor/configurations/mention/mentionConfig.js
@@ -10,36 +10,72 @@ export const mentionConfig = {
     }
 };
 
-const items = [
-    {id: '##authorname', name: 'Author name', text: '##authorname##'},
-    {id: '##creationdate', name: 'Creation date', text: '##creationdate##'},
-    {id: '##keywords', name: 'Keywords', text: '##keywords##'},
-    {id: '##linktohomepage', name: 'Link to home page', text: '##linktohomepage##'},
-    {id: '##linktoparent', name: 'Link to parent', text: '##linktoparent##'},
-    {id: '##requestParameters', name: 'Request parameters', text: '##requestParameters##'},
-    {id: '##resourceBundle', name: 'Resource bundle', text: '##resourceBundle(bundleName, key)##'},
-    {id: '##username', name: 'User name', text: '##username##'}
-];
+const CACHE_DURATION = 0.5 * 60 * 1000; // 30 seconds in milliseconds
+let cachedData = null;
+let cacheTimestamp = null;
 
 function getFeedItems(queryText) {
     return new Promise(resolve => {
-        // This simulates a request
-        setTimeout(() => {
-            const itemsToDisplay = items
-                .filter(isItemMatching)
-                .slice(0, 10);
+        try {
+            const now = Date.now();
 
-            resolve(itemsToDisplay);
-        }, 100);
+            // Check if we have valid cached data
+            if (cachedData && cacheTimestamp && (now - cacheTimestamp) < CACHE_DURATION) {
+                // Use cached data
+                const filteredItems = filterAndProcessItems(cachedData, queryText);
+                resolve(filteredItems);
+                return;
+            }
+
+            // Fetch fresh data
+            const contextPath = (window.contextJsParameters && window.contextJsParameters.contextPath) || '';
+            const initializerURL = `${window.location.protocol}//${window.location.host}${contextPath}/cms/initializers`;
+            fetch(initializerURL, {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded',
+                    Accept: 'application/json'
+                },
+                body: `initializers=choicelistmacros&name=macros&nodeuuid=${window.contextJsParameters.siteUuid}`
+            }).then(response => {
+                if (response.ok) {
+                    return response.json();
+                }
+
+                return null;
+            }).then(json => {
+                if (json === null) {
+                    resolve([]);
+                } else {
+                    // Update cache
+                    cachedData = json;
+                    cacheTimestamp = Date.now();
+
+                    const filteredItems = filterAndProcessItems(json, queryText);
+                    resolve(filteredItems);
+                }
+            });
+        } catch (e) {
+            console.error('Failed to call macros initializer', e);
+            resolve([]);
+        }
     });
+}
 
-    function isItemMatching(item) {
-        const searchString = queryText.toLowerCase();
-        return (
-            item.name.toLowerCase().includes(searchString) ||
-            item.id.toLowerCase().includes(searchString)
-        );
-    }
+function filterAndProcessItems(json, queryText) {
+    const config = window?.contextJsParameters?.config?.ckeditor5;
+    const serverItems = json.map(item => ({
+        id: item.value[0],
+        name: item.name[0].replace(/##/g, ''),
+        text: item.value[0]
+    })).filter(item => !config?.excludeMacros?.includes(item.name));
+
+    return serverItems
+        .filter(item => {
+            const searchString = queryText.toLowerCase();
+            return item.name.toLowerCase().includes(searchString);
+        })
+        .slice(0, 10);
 }
 
 function customItemRenderer(item) {

--- a/src/javascript/CKEditor/configurations/mention/mentionConfig.js
+++ b/src/javascript/CKEditor/configurations/mention/mentionConfig.js
@@ -42,6 +42,7 @@ function getFeedItems(queryText) {
                     return response.json();
                 }
 
+                console.warn('Failed to get macros, make sure a module with macros is properly deployed.');
                 return null;
             }).then(json => {
                 if (json === null) {
@@ -56,7 +57,7 @@ function getFeedItems(queryText) {
                 }
             });
         } catch (e) {
-            console.error('Failed to call macros initializer', e);
+            console.warn('Failed to call macros initializer', e);
             resolve([]);
         }
     });

--- a/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
+++ b/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
@@ -25,11 +25,13 @@ public class RichTextConfig implements ManagedService {
     private final static String INCLUDE_SITES = "includeSites";
     private final static String EXCLUDE_SITES = "excludeSites";
     private final static String EXCLUDE_TOOLBARS = "excludeToolbarItems";
+    private final static String EXCLUDE_MACROS = "excludeMacros";
     private final static String ENABLED_BY_DEFAULT = "enabledByDefault";
     private final static String CONFIG_TYPE = "configType";
 
     private boolean enabledByDefault = true;
     private List<String> excludeToolbarItems  = new ArrayList<>();
+    private List<String> excludeMacros = new ArrayList<>();
     private List<String> includeSites = new ArrayList<>();
     private List<String> excludeSites = new ArrayList<>();
     private List<CKEditorConfiguration> configs = new ArrayList<>();
@@ -51,12 +53,13 @@ public class RichTextConfig implements ManagedService {
             includeSites = getListOfStrings(values.getList(INCLUDE_SITES));
             excludeSites = getListOfStrings(values.getList(EXCLUDE_SITES));
             excludeToolbarItems = getListOfStrings(values.getList(EXCLUDE_TOOLBARS));
+            excludeMacros = getListOfStrings(values.getList(EXCLUDE_MACROS));
 
             enabledByDefault = getBoolean(dictionary, ENABLED_BY_DEFAULT);
             configType = (dictionary.get(CONFIG_TYPE) != null)
                     ? dictionary.get(CONFIG_TYPE).toString() : "complete";
-            logger.debug("Richtext configuration updated: enabledByDefault={}, includeSites={}, excludeSites={}, excludeToolbarItems={}, configType={}",
-                    enabledByDefault, StringUtils.join(includeSites, ','), StringUtils.join(excludeSites, ','), StringUtils.join(excludeToolbarItems, ','), configType);
+            logger.debug("Richtext configuration updated: enabledByDefault={}, includeSites={}, excludeSites={}, excludeToolbarItems={}, excludeMacros={}, configType={}",
+                    enabledByDefault, StringUtils.join(includeSites, ','), StringUtils.join(excludeSites, ','), StringUtils.join(excludeToolbarItems, ','), StringUtils.join(excludeMacros, ','), configType);
         }
     }
 
@@ -68,12 +71,17 @@ public class RichTextConfig implements ManagedService {
         return excludeToolbarItems;
     }
 
+    public List<String> getExcludeMacros() {
+        return excludeMacros;
+    }
+
     public JSONObject toJSON() {
         JSONObject obj = new JSONObject();
         obj.put(ENABLED_BY_DEFAULT, enabledByDefault);
         obj.put(INCLUDE_SITES, new JSONArray(includeSites));
         obj.put(EXCLUDE_SITES, new JSONArray(excludeSites));
         obj.put(EXCLUDE_TOOLBARS, new JSONArray(excludeToolbarItems));
+        obj.put(EXCLUDE_MACROS, new JSONArray(excludeMacros));
         obj.put(CONFIG_TYPE, configType);
         return obj;
     }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtextCKEditor5.yaml
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtextCKEditor5.yaml
@@ -2,6 +2,11 @@
 ## Possible usages and options
 #
 enabledByDefault: true
+excludeMacros:
+  - sessionid
+  - devmode
+  - userprofiledata
+  - getConstant
 #configs:
 ##  Will apply first available/matching config, permission is optional
 #  - siteKeys:


### PR DESCRIPTION
### Description
Use choicelist values for macros. Cache the value for 30 seconds to prevent over querying when macros is required. Add config to be able to exclude certain macros from the list. If no values are found nothing happens, we don't display anything.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
