### PR TITLE
feat: make ck5 enabled if ck4 not available

### DIFF
--- a/.chachalog/tuPiUHFQ.md
+++ b/.chachalog/tuPiUHFQ.md
@@ -1,0 +1,5 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+Use CK5 is CK4 is not installed.

--- a/docs/ckeditor5.md
+++ b/docs/ckeditor5.md
@@ -25,6 +25,8 @@ Once the CK5 module is started, every new website created on the platform will u
 
 To activate CK5 on a pre-existing website, the first thing to do is to remove this site from the exclude list in the cfg file.
 
+If the CK4 module (`ckeditor`) is not installed at all, CK5 is used unconditionally for every site, regardless of `enabledByDefault`, `includeSites` or `excludeSites` — there is no CK4 fallback to honor.
+
 ## Configuration
 
 A configuration is the name given to a specific CK5 toolbar and its underlying plugins.

--- a/src/javascript/RichTextCKEditor5/editorHooks.js
+++ b/src/javascript/RichTextCKEditor5/editorHooks.js
@@ -11,6 +11,12 @@ export const editorOnBeforeContextHook = async editContext => {
         const siteKey = editContext.siteInfo.path.split('/')[2];
         const config = contextJsParameters.config.ckeditor5;
 
+        if (config.ckeditor4Installed === false) {
+            registry.addOrReplace('selectorType', 'RichText', registry.get('selectorType', 'RichText5'));
+            resolve();
+            return;
+        }
+
         if (config.excludeSites.includes(siteKey) && config.includeSites.includes(siteKey)) {
             console.warn('The site is marked to be used with both CKEditor 4 and 5, version 5 will be used. See configuration for details.');
         }
@@ -26,6 +32,10 @@ export const editorOnBeforeContextHook = async editContext => {
 };
 
 export const editorOnCloseHook = () => {
+    if (contextJsParameters.config.ckeditor5.ckeditor4Installed === false) {
+        return;
+    }
+
     if (originalRichText) {
         registry.addOrReplace('selectorType', 'RichText', originalRichText);
     }

--- a/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
+++ b/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
@@ -1,16 +1,15 @@
 package org.jahia.modules.ckeditor.config;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jahia.osgi.BundleUtils;
 import org.jahia.services.modulemanager.util.PropertiesList;
 import org.jahia.services.modulemanager.util.PropertiesManager;
 import org.jahia.services.modulemanager.util.PropertiesValues;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.osgi.framework.Bundle;
-import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
-import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,15 +45,8 @@ public class RichTextConfig implements ManagedService {
 
     private static final Logger logger = LoggerFactory.getLogger(RichTextConfig.class);
 
-    private BundleContext bundleContext;
-
     public RichTextConfig() {
         super();
-    }
-
-    @Activate
-    public void activate(BundleContext bundleContext) {
-        this.bundleContext = bundleContext;
     }
 
     @Override
@@ -108,15 +100,8 @@ public class RichTextConfig implements ManagedService {
     }
 
     private boolean isCkeditor4Installed() {
-        if (bundleContext == null) {
-            return true;
-        }
-        for (Bundle bundle : bundleContext.getBundles()) {
-            if (CKEDITOR4_BUNDLE_SYMBOLIC_NAME.equals(bundle.getSymbolicName()) && bundle.getState() == Bundle.ACTIVE) {
-                return true;
-            }
-        }
-        return false;
+        Bundle bundle = BundleUtils.getBundleBySymbolicName(CKEDITOR4_BUNDLE_SYMBOLIC_NAME, null);
+        return bundle != null && bundle.getState() == Bundle.ACTIVE;
     }
 
     private boolean getBoolean(Dictionary<String, ?> properties, String key) {

--- a/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
+++ b/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
@@ -6,8 +6,11 @@ import org.jahia.services.modulemanager.util.PropertiesManager;
 import org.jahia.services.modulemanager.util.PropertiesValues;
 import org.json.JSONArray;
 import org.json.JSONObject;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
 import org.osgi.service.cm.ConfigurationException;
 import org.osgi.service.cm.ManagedService;
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -28,6 +31,8 @@ public class RichTextConfig implements ManagedService {
     private final static String EXCLUDE_MACROS = "excludeMacros";
     private final static String ENABLED_BY_DEFAULT = "enabledByDefault";
     private final static String CONFIG_TYPE = "configType";
+    private final static String CKEDITOR4_INSTALLED = "ckeditor4Installed";
+    private final static String CKEDITOR4_BUNDLE_SYMBOLIC_NAME = "ckeditor";
     private final static String AI_TYPE = "aiType";
 
     private boolean enabledByDefault = true;
@@ -41,8 +46,15 @@ public class RichTextConfig implements ManagedService {
 
     private static final Logger logger = LoggerFactory.getLogger(RichTextConfig.class);
 
+    private BundleContext bundleContext;
+
     public RichTextConfig() {
         super();
+    }
+
+    @Activate
+    public void activate(BundleContext bundleContext) {
+        this.bundleContext = bundleContext;
     }
 
     @Override
@@ -91,7 +103,20 @@ public class RichTextConfig implements ManagedService {
         obj.put(EXCLUDE_TOOLBARS, new JSONArray(excludeToolbarItems));
         obj.put(EXCLUDE_MACROS, new JSONArray(excludeMacros));
         obj.put(CONFIG_TYPE, configType);
+        obj.put(CKEDITOR4_INSTALLED, isCkeditor4Installed());
         return obj;
+    }
+
+    private boolean isCkeditor4Installed() {
+        if (bundleContext == null) {
+            return true;
+        }
+        for (Bundle bundle : bundleContext.getBundles()) {
+            if (CKEDITOR4_BUNDLE_SYMBOLIC_NAME.equals(bundle.getSymbolicName()) && bundle.getState() == Bundle.ACTIVE) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private boolean getBoolean(Dictionary<String, ?> properties, String key) {


### PR DESCRIPTION
### Description
This PR makes sure CK5 is used if CK4 is not installed, regardless of config eligibility.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
