### PR TITLE
fix: Allow streaming instead of buffering AI response

### DIFF
--- a/src/main/java/org/jahia/modules/ckeditor/ai/service/impl/OpenAIProxyServiceImpl.java
+++ b/src/main/java/org/jahia/modules/ckeditor/ai/service/impl/OpenAIProxyServiceImpl.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
 import java.io.*;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -146,11 +147,28 @@ public class OpenAIProxyServiceImpl implements AIProxyService {
     }
 
     private Response handleJsonResponse(HttpResponse<InputStream> response) {
-        return Response.ok(response.body()).build();
+        StreamingOutput streamingOutput = output -> {
+            try (InputStream input = response.body()) {
+                input.transferTo(output); // 8KB buffer
+            }
+        };
+        return Response.ok(streamingOutput).type(MediaType.APPLICATION_JSON).build();
     }
 
     private Response handleStreamingResponse(HttpResponse<InputStream> response) {
-        return Response.ok(response.body())
+        // We avoid buffering the entire response in memory by default, and flush each read SSE chunk immediately
+        StreamingOutput streamingOutput = output -> {
+            try (InputStream input = response.body()) {
+                byte[] buffer = new byte[1024];
+                int bytesRead;
+                while ((bytesRead = input.read(buffer)) != -1) {
+                    output.write(buffer, 0, bytesRead);
+                    output.flush();
+                }
+            }
+        };
+
+        return Response.ok(streamingOutput)
                 .type("text/event-stream")
                 .header("Cache-Control", "no-cache")
                 .header("Connection", "keep-alive")


### PR DESCRIPTION
### Description

Current implementation buffers SSE streaming response, which can potentially cause a long wait in the UI instead of getting incremental text in the UI. Fix is to flush output as soon as we get an SSE chunk immediately. We also adjust json response to 8KB buffer instead of full response buffer.

