### PR TITLE
fix: Enable/disable AI menu bar entries in visibility logic

### DIFF
--- a/.chachalog/V-oVlMF7.md
+++ b/.chachalog/V-oVlMF7.md
@@ -3,5 +3,5 @@
 richtext-ckeditor5: minor
 ---
 
-Added AI Assistant support with a server-side proxy for OpenAI (#316)
+Added AI Assistant support with a server-side proxy for OpenAI (#316, #317, #319)
   - OpenAI request parameters and key configured through OSGi configuration

--- a/src/javascript/CKEditor/config.utils.js
+++ b/src/javascript/CKEditor/config.utils.js
@@ -31,6 +31,14 @@ export function getAIConfig(nodePath, config) {
     const isAIEnabled = Boolean(window?.contextJsParameters?.config?.ckeditor5?.aiEnabled);
     if (!isAIEnabled) {
         removeToolbarItems(config, ['aiCommands', 'aiAssistant']);
+        if (config.menuBar) {
+            config.menuBar.removeItems = [
+                ...(config.menuBar.removeItems ?? []),
+                'menuBar:aiCommands',
+                'menuBar:aiAssistant'
+            ];
+        }
+
         return {};
     }
 

--- a/tests/cypress/e2e/aiAssistant.cy.ts
+++ b/tests/cypress/e2e/aiAssistant.cy.ts
@@ -40,6 +40,9 @@ describe('AI Assistant tests', () => {
             ck5field.getToolbarButton('AI Assistant').should('not.exist');
             ck5field.getToolbarButton('AI Commands').should('not.exist');
 
+            ck5field.assertMenuBarDoesNotContain('Tools', 'AI Assistant');
+            ck5field.assertMenuBarDoesNotContain('Tools', 'AI Commands');
+
             ckeditor5.cancelAndDiscard();
         });
 
@@ -59,6 +62,10 @@ describe('AI Assistant tests', () => {
 
             ck5field.getToolbarButton('AI Assistant').should('be.visible');
             ck5field.getToolbarButton('AI Commands').should('be.visible');
+
+            ck5field.clickMenuItemByLabel('Tools');
+            ck5field.getMenuSubItemByLabel('AI Assistant').should('be.visible');
+            ck5field.getMenuSubItemByLabel('AI Commands').should('be.visible');
 
             ckeditor5.cancelAndDiscard();
         });

--- a/tests/cypress/page-object/ckeditor5.ts
+++ b/tests/cypress/page-object/ckeditor5.ts
@@ -83,6 +83,23 @@ export class RichTextCKeditor5Field extends Field {
         return this.get().find('.ck-menu-bar').find('ul.ck-list li.ck-list__item button.ck-list-item-button').contains(label);
     }
 
+    assertMenuBarDoesNotContain(parentMenuLabel: string, label: string): void {
+        this.get().find('div.ck-menu-bar__menu_top-level > button.ck-menu-bar__menu__button').then($buttons => {
+            const $parentBtn = $buttons.filter((_, el) => el.textContent?.trim() === parentMenuLabel);
+            if ($parentBtn.length === 0) {
+                // Parent menu is absent entirely — child item cannot be present
+                return;
+            }
+
+            // Parent menu exists — open it and verify the label is not among its items
+            cy.wrap($parentBtn).click();
+            this.get()
+                .find('.ck-menu-bar')
+                .find('ul.ck-list li.ck-list__item button.ck-list-item-button')
+                .should('not.contain', label, {timeout: 10000});
+        });
+    }
+
     selectHeading(heading: string) {
         this.get().find('.ck-heading-dropdown').find('.ck-list__item').contains(heading).click();
     }


### PR DESCRIPTION
### Description

Fix issue https://github.com/Jahia/richtext-ckeditor5/issues/318

Remove menu bar items, not just toolbar buttons, for AI assistant when AI config is disabled. 

Cypress coverage added
