### PR TITLE
feat: Add richtext max height in config

### DIFF
--- a/.chachalog/SD1y2a2-.md
+++ b/.chachalog/SD1y2a2-.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Add optional richtext max-height (`richtextMaxHeight`) in CK5 configuration (#325)

--- a/docs/ckeditor5.md
+++ b/docs/ckeditor5.md
@@ -160,6 +160,17 @@ Apart from this site key ordering, the first configuration that satisfies all co
 
 **Set the most powerful toolbars first,** so that users with broader permissions do not get matched to configurations intended for more restricted roles.
 
+### Editor Max Height
+
+By default, the editor content area grows to fit its content with no upper limit. You can cap this height by setting `richtextMaxHeight` in the global configuration file:
+
+```
+# Accepts a positive integer (pixels)
+richtextMaxHeight=500
+```
+
+Once the content exceeds this height, the editor becomes scrollable.
+
 #### CND configuration
 
 Configuration can also be defined at the CND level. In this case, the configuration is applied directly to the specified field within the content definition, overriding any global or site-specific configuration.

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.jsx
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.jsx
@@ -89,8 +89,9 @@ export const RichTextCKEditor5 = ({field, id, value, onChange, onBlur}) => {
         customConfig.translations = translations.slice();
     }
 
+    const richtextMaxHeight = window?.contextJsParameters?.config?.ckeditor5?.richtextMaxHeight;
     return (
-        <div className={styles.unreset}>
+        <div className={styles.unreset} style={richtextMaxHeight ? {'--ck-editor-max-height': `${richtextMaxHeight}px`} : undefined}>
             <CKEditor
                 id={id}
                 editor={JahiaClassicEditor}
@@ -100,6 +101,7 @@ export const RichTextCKEditor5 = ({field, id, value, onChange, onBlur}) => {
                 onReady={editor => {
                     editorRef.current = editor;
                     editor.editing.view.change(writer => {
+                        // Applied to [contenteditable="true"] element, which is the main editing area of CKEditor
                         writer.addClass(styles.wrapper, editor.editing.view.document.getRoot());
                     });
                 }}

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.scss
@@ -15,6 +15,7 @@
   overflow-y: auto;
   min-height: 20vh;
   height: fit-content;
+  max-height: var(--ck-editor-max-height, none);
 }
 
 

--- a/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
+++ b/src/main/java/org/jahia/modules/ckeditor/config/RichTextConfig.java
@@ -33,6 +33,7 @@ public class RichTextConfig implements ManagedService {
     private final static String CKEDITOR4_INSTALLED = "ckeditor4Installed";
     private final static String CKEDITOR4_BUNDLE_SYMBOLIC_NAME = "ckeditor";
     private final static String AI_TYPE = "aiType";
+    private final static String RICHTEXT_MAX_HEIGHT = "richtextMaxHeight";
 
     private boolean enabledByDefault = true;
     private List<String> excludeToolbarItems  = new ArrayList<>();
@@ -42,6 +43,7 @@ public class RichTextConfig implements ManagedService {
     private List<CKEditorConfiguration> configs = new ArrayList<>();
     private String configType = "complete";
     private String aiType = "openai";
+    private String richtextMaxHeight = null;
 
     private static final Logger logger = LoggerFactory.getLogger(RichTextConfig.class);
 
@@ -66,8 +68,9 @@ public class RichTextConfig implements ManagedService {
                     ? dictionary.get(CONFIG_TYPE).toString() : "complete";
             aiType = (dictionary.get(AI_TYPE) != null)
                     ? dictionary.get(AI_TYPE).toString() : "openai";
-            logger.debug("Richtext configuration updated: enabledByDefault={}, includeSites={}, excludeSites={}, excludeToolbarItems={}, excludeMacros={}, configType={}",
-                    enabledByDefault, StringUtils.join(includeSites, ','), StringUtils.join(excludeSites, ','), StringUtils.join(excludeToolbarItems, ','), StringUtils.join(excludeMacros, ','), configType);
+            richtextMaxHeight = parsePositiveValue(dictionary, RICHTEXT_MAX_HEIGHT);
+            logger.debug("Richtext configuration updated: enabledByDefault={}, includeSites={}, excludeSites={}, excludeToolbarItems={}, excludeMacros={}, configType={}, richtextMaxHeight={}",
+                    enabledByDefault, StringUtils.join(includeSites, ','), StringUtils.join(excludeSites, ','), StringUtils.join(excludeToolbarItems, ','), StringUtils.join(excludeMacros, ','), configType, richtextMaxHeight);
         }
     }
 
@@ -87,6 +90,10 @@ public class RichTextConfig implements ManagedService {
         return aiType;
     }
 
+    public String getRichtextMaxHeight() {
+        return richtextMaxHeight;
+    }
+
     public JSONObject toJSON() {
         JSONObject obj = new JSONObject();
         obj.put(ENABLED_BY_DEFAULT, enabledByDefault);
@@ -96,6 +103,9 @@ public class RichTextConfig implements ManagedService {
         obj.put(EXCLUDE_MACROS, new JSONArray(excludeMacros));
         obj.put(CONFIG_TYPE, configType);
         obj.put(CKEDITOR4_INSTALLED, isCkeditor4Installed());
+        if (richtextMaxHeight != null) {
+            obj.put(RICHTEXT_MAX_HEIGHT, richtextMaxHeight);
+        }
         return obj;
     }
 
@@ -141,5 +151,36 @@ public class RichTextConfig implements ManagedService {
 
     private List<String> getListOfStrings(PropertiesList list) {
         return list.getStructuredList().stream().map(obj -> Objects.toString(obj, null)).collect(Collectors.toList());
+    }
+
+    /**
+     * Parses an optional positive integer value from the configuration dictionary.
+     * Only digits are accepted — any other characters are stripped before parsing.
+     * Returns null if the key is absent, blank, or does not result in a positive integer.
+     */
+    private String parsePositiveValue(Dictionary<String, ?> properties, String key) {
+        if (properties == null || properties.get(key) == null) {
+            return null;
+        }
+        String raw = properties.get(key).toString().trim();
+        if (raw.isEmpty()) {
+            return null;
+        }
+        // Sanitize: keep digits only
+        String sanitized = raw.replaceAll("[^0-9]", "");
+        if (sanitized.isEmpty()) {
+            logger.warn("Invalid value for {}: '{}'. Expected a positive integer (number of pixels).", key, raw);
+            return null;
+        }
+        try {
+            int intValue = Integer.parseInt(sanitized);
+            if (intValue > 0) {
+                return String.valueOf(intValue);
+            }
+        } catch (NumberFormatException e) {
+            logger.warn("Invalid value for {}: '{}'. Expected a positive integer (number of pixels).", key, raw);
+        }
+        logger.warn("Ignoring non-positive value for {}: '{}'.", key, raw);
+        return null;
     }
 }

--- a/src/main/resources/META-INF/configurations/org.jahia.modules.richtextCKEditor5.cfg
+++ b/src/main/resources/META-INF/configurations/org.jahia.modules.richtextCKEditor5.cfg
@@ -31,3 +31,8 @@ excludeMacros[3]=getConstant
 
 # excludeToolbarItems[0]=item1
 # excludeToolbarItems[1]=item2
+
+# richtextMaxHeight: Optional. Sets a maximum height for the editor content area.
+# Accepts a positive integer representing a height in pixels.
+# When set, the editor becomes scrollable once the content exceeds this height.
+# richtextMaxHeight=500

--- a/tests/cypress/e2e/richtextMaxHeight.cy.ts
+++ b/tests/cypress/e2e/richtextMaxHeight.cy.ts
@@ -59,7 +59,6 @@ describe('Rich Text CKEditor 5 - richtextMaxHeight config', () => {
     // Helper methods
 
     const setRichtextMaxHeight = (value: string) => {
-
         cy.apollo({
             mutation: gql`
                 mutation SetRichtextMaxHeight($value: String!) {
@@ -88,7 +87,7 @@ describe('Rich Text CKEditor 5 - richtextMaxHeight config', () => {
                         }
                     }
                 }
-            `,
-        })
-    }
+            `
+        });
+    };
 });

--- a/tests/cypress/e2e/richtextMaxHeight.cy.ts
+++ b/tests/cypress/e2e/richtextMaxHeight.cy.ts
@@ -1,0 +1,94 @@
+import {JContent} from '@jahia/jcontent-cypress/dist/page-object';
+import {Ckeditor5, RichTextCKeditor5Field} from '../page-object/ckeditor5';
+import gql from 'graphql-tag';
+import {createSite, deleteSite} from '@jahia/cypress';
+
+describe('Rich Text CKEditor 5 - richtextMaxHeight config', () => {
+    const siteKey = 'richtextMaxHeightTestSite';
+
+    before(function () {
+        createSite(siteKey);
+    });
+
+    after(function () {
+        cy.logout();
+        deleteSite(siteKey);
+    });
+
+    beforeEach(() => {
+        cy.loginAndStoreSession();
+    });
+
+    afterEach(() => {
+        removeRichtextMaxHeight();
+    });
+
+    it('Applies the configured max-height to the editable area', function () {
+        const MAX_HEIGHT_PX = 500;
+        setRichtextMaxHeight(String(MAX_HEIGHT_PX));
+
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        jcontent.createContent('jnt:bigText');
+        const ckeditor5 = new Ckeditor5();
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+
+        /**
+         * The editable root ([contenteditable="true"]) is the element that receives the
+         * `styles.wrapper` CSS class, which reads the --ck-editor-max-height CSS variable
+         * set by the React component.
+         *
+         * We check the CSS max-height property directly (not the rendered height), so the
+         * value will always be exactly `${MAX_HEIGHT_PX}px` with no sub-pixel variance.
+         */
+        ck5field.getEditArea()
+            .invoke('css', 'max-height')
+            .should('eq', `${MAX_HEIGHT_PX}px`);
+    });
+
+    it('Does not apply max-height when richtextMaxHeight is not configured', function () {
+        const jcontent = JContent.visit(siteKey, 'en', 'content-folders/contents');
+        jcontent.createContent('jnt:bigText');
+        const ckeditor5 = new Ckeditor5();
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+
+        ck5field.getEditArea()
+            .invoke('css', 'max-height')
+            .should('eq', 'none');
+    });
+
+    // Helper methods
+
+    const setRichtextMaxHeight = (value: string) => {
+
+        cy.apollo({
+            mutation: gql`
+                mutation SetRichtextMaxHeight($value: String!) {
+                    admin {
+                        jahia {
+                            configuration(pid: "org.jahia.modules.richtextCKEditor5") {
+                                value(name: "richtextMaxHeight", value: $value)
+                            }
+                        }
+                    }
+                }
+            `,
+            variables: {value}
+        });
+    };
+
+    const removeRichtextMaxHeight = () => {
+        cy.apollo({
+            mutation: gql`
+                mutation {
+                    admin {
+                        jahia {
+                            configuration(pid: "org.jahia.modules.richtextCKEditor5") {
+                                remove(name: "richtextMaxHeight")
+                            }
+                        }
+                    }
+                }
+            `,
+        })
+    }
+});


### PR DESCRIPTION
### Description

Add optional configuration `richtextMaxHeight` for adding a max-height in CK5 richtext instances.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [x] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
