### PR TITLE
fix: encode URL coming from plugins

### DIFF
--- a/.chachalog/B8RDhbS0.md
+++ b/.chachalog/B8RDhbS0.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: patch
+---
+
+Links coming from link picker and image picker are encoded now, and support `+` symbols in them.

--- a/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImageCommand.js
+++ b/src/javascript/CKEditor/Picker/InsertJahiaImage/InsertJahiaImageCommand.js
@@ -1,4 +1,5 @@
 import {Command} from 'ckeditor5';
+import {encodePath} from '../../../RichTextCKEditor5/RichTextCKEditor5.utils';
 
 export class InsertJahiaImageCommand extends Command {
     constructor(editor, type) {
@@ -43,7 +44,7 @@ export class InsertJahiaImageCommand extends Command {
                         });
                     }
 
-                    editor.execute('imageInsert', {source: `${contentPicker ? contentPrefix : filePrefix}${pickerResult.path}${contentPicker ? '.html' : ''}`});
+                    editor.execute('imageInsert', {source: `${contentPicker ? contentPrefix : filePrefix}${encodePath(pickerResult.path)}${contentPicker ? '.html' : ''}`});
                 });
             },
             ...pickerConfig

--- a/src/javascript/CKEditor/Picker/JahiaLinkProvider.js
+++ b/src/javascript/CKEditor/Picker/JahiaLinkProvider.js
@@ -1,5 +1,5 @@
 import {Plugin, LinkUI} from 'ckeditor5';
-import {loadTranslations} from '../../RichTextCKEditor5/RichTextCKEditor5.utils';
+import {encodePath, loadTranslations} from '../../RichTextCKEditor5/RichTextCKEditor5.utils';
 
 export class JahiaLinkProvider extends Plugin {
     static contextPath = (window.contextJsParameters && window.contextJsParameters.contextPath) || '';
@@ -74,7 +74,7 @@ export class JahiaLinkProvider extends Plugin {
         // Editorial link picker config
         window.CE_API.openPicker({
             setValue: pickerResults => {
-                const url = `${JahiaLinkProvider.contentPrefix}${pickerResults[0].path}.html`;
+                const url = `${JahiaLinkProvider.contentPrefix}${encodePath(pickerResults[0].path)}.html`;
                 editor.execute('link', url);
             },
             type: 'editoriallink',
@@ -92,7 +92,7 @@ export class JahiaLinkProvider extends Plugin {
         // File picker config
         window.CE_API.openPicker({
             setValue: pickerResults => {
-                const url = `${JahiaLinkProvider.filePrefix}${pickerResults[0].path}`;
+                const url = `${JahiaLinkProvider.filePrefix}${encodePath(pickerResults[0].path)}`;
                 editor.execute('link', url);
             },
             type: 'file',

--- a/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
+++ b/src/javascript/RichTextCKEditor5/RichTextCKEditor5.utils.js
@@ -57,6 +57,16 @@ export const set = (target, path, value) => {
     }
 };
 
+/**
+ * URL-encode each segment of a Jahia node path (preserving '/' separators) so that
+ * special characters such as '+' and spaces in folder/file names survive server-side
+ * link resolution. Inverse of the decodeURIComponent done in JahiaLinkProvider.getPickerValue.
+ *
+ * @param {string} path the raw node path returned by the picker, e.g. /sites/x/files/test + test/f.pdf
+ * @returns {string} the path with each segment URL-encoded
+ */
+export const encodePath = path => path.split('/').map(encodeURIComponent).join('/');
+
 export const isProductivityMode = () => {
     /**
      * CKEDITOR_PRODUCTIVITY_LICENSE is inserted as a literal string by webpack using define plugin.

--- a/tests/cypress/e2e/link.cy.ts
+++ b/tests/cypress/e2e/link.cy.ts
@@ -1,6 +1,6 @@
 import {JContent} from '@jahia/jcontent-cypress/dist/page-object';
 import {Picker} from '@jahia/jcontent-cypress/dist/page-object/picker';
-import {addNode, createSite, deleteSite, getComponentByAttr} from '@jahia/cypress';
+import {addNode, createSite, deleteSite, getComponentByAttr, uploadFile} from '@jahia/cypress';
 import {Ckeditor5, RichTextCKeditor5Field} from '../page-object/ckeditor5';
 
 const openLinkPicker = ck5field => {
@@ -34,6 +34,13 @@ describe('Link tests', () => {
                 {name: 'j:templateName', value: '2-column'}
             ]
         });
+        // Folder with a '+' in its name + a file inside, to test URL-encoding of picker paths
+        addNode({
+            parentPathOrId: `/sites/${siteKey}/files`,
+            name: 'test + test',
+            primaryNodeType: 'jnt:folder'
+        });
+        uploadFile('placeholder.jpg', `/sites/${siteKey}/files/test + test`, 'test.jpg', 'image/jpeg');
     });
 
     after(function () {
@@ -122,5 +129,28 @@ describe('Link tests', () => {
         picker.getTable().getRowByName('css').get().dblclick();
         picker.getTable().getRowByName('bootstrap.css').get().click();
         picker.select();
+    });
+
+    it('should insert a file link from a folder whose name contains "+" without validation error', () => {
+        JContent.visit(siteKey, 'en', `content-folders/contents/${textName}`).editContent();
+        const ck5field: RichTextCKeditor5Field = ckeditor5.getRichTextCKeditor5Field('jnt:bigText_text');
+        ck5field.getEditArea().contains('my text').click('center');
+
+        openLinkPicker(ck5field);
+
+        ck5field.getBalloonToolbarButton('Edit link').should('be.visible').click();
+        ck5field.getBalloonButton('Jahia internal files').should('be.visible').click();
+
+        const picker = getComponentByAttr(Picker, 'data-sel-role', 'picker-dialog');
+        picker.getTable().getRowByName('test + test').get().dblclick();
+        picker.getTable().getRowByName('test.jpg').get().click();
+        picker.select();
+
+        cy.log('Path must be URL-encoded so the server can resolve it: \' \' -> %20, \'+\' -> %2B');
+        ck5field.getEditArea().find('a')
+            .should('have.attr', 'href')
+            .and('contain', `${encodeURIComponent('test + test')}/test.jpg`);
+
+        ckeditor5.save();
     });
 });


### PR DESCRIPTION
### Description
This PR fixes a bug with `+` symbol in links coming from jahia plugins in CK5.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
