### PR TITLE
ci: Fix package.json maven sync plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,23 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-scm-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>package-json</id>
+                        <phase>none</phase>
+                        <goals>
+                            <goal>checkin</goal>
+                        </goals>
+                        <configuration>
+                            <includes>package.json,tests/package.json</includes>
+                            <message>[maven-scm-plugin] [skip ci] synchronize package.json</message>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
                     <preparationGoals>clean verify frontend:yarn@sync-pom frontend:yarn@sync-pom-tests scm:checkin@package-json</preparationGoals>


### PR DESCRIPTION
### Description

Context: Added [sync-pom step](https://github.com/Jahia/richtext-ckeditor5/pull/335) to sync package.json versions but is now [causing an issue](https://github.com/Jahia/richtext-ckeditor5/actions/runs/26761427430/job/78875745017#step:7:2138) on release:

```
Error: [ERROR] Failed to execute goal org.apache.maven.plugins:maven-scm-plugin:2.0.1:checkin (package-json) on project richtext-ckeditor5: 
Cannot run checkin command : Exception while executing SCM command. 
Missing parameter: 'message'. -> [Help 1]
```

Need to add missing plugin definition for the `scm:checkin` part

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
