### PR TITLE
feat: Mask openai key in config

### DIFF
--- a/.chachalog/tHIhIyhO.md
+++ b/.chachalog/tHIhIyhO.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: patch
+---
+
+Mask openai key in config (#340)

--- a/src/main/java/org/jahia/modules/ckeditor/ai/service/impl/OpenAIConfigMetatype.java
+++ b/src/main/java/org/jahia/modules/ckeditor/ai/service/impl/OpenAIConfigMetatype.java
@@ -24,6 +24,7 @@
 package org.jahia.modules.ckeditor.ai.service.impl;
 
 import org.osgi.service.metatype.annotations.AttributeDefinition;
+import org.osgi.service.metatype.annotations.AttributeType;
 import org.osgi.service.metatype.annotations.ObjectClassDefinition;
 
 @ObjectClassDefinition(
@@ -36,7 +37,7 @@ public @interface OpenAIConfigMetatype {
     boolean ai_enabled() default false;
 
     // From https://platform.openai.com/api-keys
-    @AttributeDefinition(name = "API Key", description = "OpenAI API Key")
+    @AttributeDefinition(name = "API Key", description = "OpenAI API Key", type = AttributeType.PASSWORD)
     String ai_apiKey() default "YOUR_OPEN_API_KEY_HERE";
 
     @AttributeDefinition(name = "API URL", description = "OpenAI API endpoint URL")

--- a/tests/jahia-module/test-ckeditor5-templates/src/main/resources/jnt_template/html/template.test-ckeditor5-templates.jsp
+++ b/tests/jahia-module/test-ckeditor5-templates/src/main/resources/jnt_template/html/template.test-ckeditor5-templates.jsp
@@ -4,6 +4,7 @@
 <%@ taglib prefix="template" uri="http://www.jahia.org/tags/templateLib" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
 <%@ taglib prefix="fn" uri="http://java.sun.com/jsp/jstl/functions" %>
+<%@ taglib prefix="jcr" uri="http://www.jahia.org/tags/jcr" %>
 <%--@elvariable id="currentNode" type="org.jahia.services.content.JCRNodeWrapper"--%>
 <%--@elvariable id="renderContext" type="org.jahia.services.render.RenderContext"--%>
 <%--@elvariable id="url" type="org.jahia.services.render.URLGenerator"--%>


### PR DESCRIPTION
### Description

Add masking for the Open AI key in config

Before:

<img width="1114" height="411" alt="image" src="https://github.com/user-attachments/assets/8af794bc-356b-4e59-a89d-e764de110488" />

After:

<img width="935" height="415" alt="image" src="https://github.com/user-attachments/assets/ce65b3be-680c-403b-89f8-32efc8511c89" />


Misc

- Fix template issue in ck5-test-template module

To manually test, just need to make sure open AI key still working when updating masked config https://github.com/Jahia/richtext-ckeditor5/issues/310
