### PR TITLE
chore: Add missing graphql description

### DIFF
--- a/.chachalog/mZupRkLh.md
+++ b/.chachalog/mZupRkLh.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+richtext-ckeditor5: minor
+---
+
+Add missing graphql description for RichTextQuery `config` parameter (#343)

--- a/src/main/java/org/jahia/modules/ckeditor/graphql/query/GqlRichTextQuery.java
+++ b/src/main/java/org/jahia/modules/ckeditor/graphql/query/GqlRichTextQuery.java
@@ -50,7 +50,11 @@ public class GqlRichTextQuery {
     @GraphQLField
     @GraphQLName("config")
     @GraphQLDescription("Returns appropriate configuration for richtext ckeditor5")
-    public GqlRichTextConfigResult validate(@GraphQLName("path") @GraphQLNonNull String path) {
+    public GqlRichTextConfigResult validate(
+        @GraphQLName("path") 
+        @GraphQLNonNull 
+        @GraphQLDescription("Node path for which to retrieve the configuration") String path
+    ) {
         try {
 
             JCRSessionWrapper session = JCRSessionFactory.getInstance().getCurrentUserSession();


### PR DESCRIPTION
### Description

Missing graphql description causing cypress test failure in [graphql-core repository PR](https://github.com/Jahia/graphql-core/actions/runs/27580873448/job/81541753972?pr=615#step:9:17117)
